### PR TITLE
Relocate to https://embedonomicon.rust-embedded.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+embedonomicon.rust-embedded.org


### PR DESCRIPTION
As mentioned in [rust-lang-nursery/embedded-wg#145](https://github.com/rust-lang-nursery/embedded-wg/pull/145)

Added a CNAME file, this requires related A records to take effect.

See https://help.github.com/articles/setting-up-an-apex-domain/ for domain setup, needs at least 2x DNS A records for `embedonomicon` on `rust-embedded.org` pointing to `185.199.108.153` and `185.199.109.153` to become active (4x A records as in the instructions if you feel like it).