### PR TITLE
move code to the 2018 edition

### DIFF
--- a/ci/exceptions/app/Cargo.toml
+++ b/ci/exceptions/app/Cargo.toml
@@ -1,7 +1,10 @@
+cargo-features = ["edition"]
+
 [package]
+authors = ["Jorge Aparicio <jorge@japaric.io>"]
+edition = "2018"
 name = "app"
 version = "0.1.0"
-authors = ["Jorge Aparicio <jorge@japaric.io>"]
 
 [dependencies]
 rt = { path = "../rt" }

--- a/ci/exceptions/app/Cargo.toml
+++ b/ci/exceptions/app/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition"]
-
 [package]
 authors = ["Jorge Aparicio <jorge@japaric.io>"]
 edition = "2018"

--- a/ci/exceptions/app/src/main.rs
+++ b/ci/exceptions/app/src/main.rs
@@ -2,10 +2,9 @@
 #![no_main]
 #![no_std]
 
-#[macro_use]
-extern crate rt;
-
 use core::intrinsics;
+
+use rt::entry;
 
 entry!(main);
 

--- a/ci/exceptions/app2/src/main.rs
+++ b/ci/exceptions/app2/src/main.rs
@@ -2,10 +2,9 @@
 #![no_main]
 #![no_std]
 
-#[macro_use]
-extern crate rt;
-
 use core::intrinsics;
+
+use rt::entry;
 
 entry!(main);
 

--- a/ci/exceptions/rt/src/lib.rs
+++ b/ci/exceptions/rt/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(panic_handler)]
 #![no_std]
 
 use core::panic::PanicInfo;

--- a/ci/exceptions/rt/src/lib.rs
+++ b/ci/exceptions/rt/src/lib.rs
@@ -37,7 +37,7 @@ pub unsafe extern "C" fn Reset() -> ! {
 pub static RESET_VECTOR: unsafe extern "C" fn() -> ! = Reset;
 
 #[panic_handler]
-fn panic(_panic: &PanicInfo) -> ! {
+fn panic(_panic: &PanicInfo<'_>) -> ! {
     loop {}
 }
 

--- a/ci/main/app/Cargo.toml
+++ b/ci/main/app/Cargo.toml
@@ -1,7 +1,5 @@
-cargo-features = ["edition"] # <-
-
 [package]
-edition = "2018" # <-
+edition = "2018"
 name = "app"
 version = "0.1.0"
 authors = ["Jorge Aparicio <jorge@japaric.io>"]

--- a/ci/main/app/Cargo.toml
+++ b/ci/main/app/Cargo.toml
@@ -1,4 +1,7 @@
+cargo-features = ["edition"] # <-
+
 [package]
+edition = "2018" # <-
 name = "app"
 version = "0.1.0"
 authors = ["Jorge Aparicio <jorge@japaric.io>"]

--- a/ci/main/app2/src/main.rs
+++ b/ci/main/app2/src/main.rs
@@ -1,8 +1,7 @@
 #![no_std]
 #![no_main]
 
-#[macro_use]
-extern crate rt;
+use rt::entry;
 
 entry!(main);
 

--- a/ci/main/app3/src/main.rs
+++ b/ci/main/app3/src/main.rs
@@ -1,8 +1,7 @@
 #![no_std]
 #![no_main]
 
-#[macro_use]
-extern crate rt;
+use rt::entry;
 
 entry!(main);
 

--- a/ci/main/app4/Cargo.toml
+++ b/ci/main/app4/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition"]
-
 [package]
 authors = ["Jorge Aparicio <jorge@japaric.io>"]
 edition = "2018"

--- a/ci/main/app4/Cargo.toml
+++ b/ci/main/app4/Cargo.toml
@@ -1,7 +1,10 @@
+cargo-features = ["edition"]
+
 [package]
+authors = ["Jorge Aparicio <jorge@japaric.io>"]
+edition = "2018"
 name = "app"
 version = "0.1.0"
-authors = ["Jorge Aparicio <jorge@japaric.io>"]
 
 [dependencies]
 rt = { path = "../rt2" }

--- a/ci/main/app4/src/main.rs
+++ b/ci/main/app4/src/main.rs
@@ -2,10 +2,9 @@
 #![no_main]
 #![no_std]
 
-#[macro_use]
-extern crate rt;
-
 use core::ptr;
+
+use rt::entry;
 
 entry!(main);
 

--- a/ci/main/rt/Cargo.toml
+++ b/ci/main/rt/Cargo.toml
@@ -1,9 +1,7 @@
-cargo-features = ["edition"]
-
 [package]
-name = "rt" # <-
-authors = ["Jorge Aparicio <jorge@japaric.io>"]
 edition = "2018"
+name = "rt" # <-
 version = "0.1.0"
+authors = ["Jorge Aparicio <jorge@japaric.io>"]
 
 [dependencies]

--- a/ci/main/rt/Cargo.toml
+++ b/ci/main/rt/Cargo.toml
@@ -1,6 +1,9 @@
+cargo-features = ["edition"]
+
 [package]
-name = "rt"
-version = "0.1.0"
+name = "rt" # <-
 authors = ["Jorge Aparicio <jorge@japaric.io>"]
+edition = "2018"
+version = "0.1.0"
 
 [dependencies]

--- a/ci/main/rt/src/lib.rs
+++ b/ci/main/rt/src/lib.rs
@@ -19,7 +19,7 @@ pub unsafe extern "C" fn Reset() -> ! {
 pub static RESET_VECTOR: unsafe extern "C" fn() -> ! = Reset;
 
 #[panic_handler]
-fn panic(_panic: &PanicInfo) -> ! {
+fn panic(_panic: &PanicInfo<'_>) -> ! {
     loop {}
 }
 

--- a/ci/main/rt/src/lib.rs
+++ b/ci/main/rt/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(panic_handler)]
 #![no_std]
 
 use core::panic::PanicInfo;

--- a/ci/main/rt2/src/lib.rs
+++ b/ci/main/rt2/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(panic_handler)]
 #![no_std]
 
 use core::panic::PanicInfo;

--- a/ci/main/rt2/src/lib.rs
+++ b/ci/main/rt2/src/lib.rs
@@ -37,7 +37,7 @@ pub unsafe extern "C" fn Reset() -> ! {
 pub static RESET_VECTOR: unsafe extern "C" fn() -> ! = Reset;
 
 #[panic_handler]
-fn panic(_panic: &PanicInfo) -> ! {
+fn panic(_panic: &PanicInfo<'_>) -> ! {
     loop {}
 }
 

--- a/ci/memory-layout/src/main.rs
+++ b/ci/memory-layout/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(panic_handler)]
 #![no_main]
 #![no_std]
 

--- a/ci/memory-layout/src/main.rs
+++ b/ci/memory-layout/src/main.rs
@@ -19,6 +19,6 @@ pub unsafe extern "C" fn Reset() -> ! {
 pub static RESET_VECTOR: unsafe extern "C" fn() -> ! = Reset;
 
 #[panic_handler]
-fn panic(_panic: &PanicInfo) -> ! {
+fn panic(_panic: &PanicInfo<'_>) -> ! {
     loop {}
 }

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -23,6 +23,8 @@ main() {
     diff app.o.nm \
          <(cargo nm -- target/thumbv7m-none-eabi/debug/deps/app-*.o | grep '[0-9]* [^n] ')
 
+    edition_check
+
     popd
 
     # # memory-layout
@@ -38,6 +40,8 @@ main() {
 
     qemu_check target/thumbv7m-none-eabi/debug/app
 
+    edition_check
+
     popd
 
     # # main
@@ -47,20 +51,25 @@ main() {
     pushd app
     diff app.objdump \
          <(cargo objdump --bin app -- -d -no-show-raw-insn)
+    # disabled because of rust-lang/rust#53964
+    # edition_check
     popd
 
     # check that it builds
     pushd app2
     cargo build
+    edition_check
     popd
 
     pushd app3
     cargo build
+    edition_check
     popd
 
     pushd app4
     cargo build
     qemu_check target/thumbv7m-none-eabi/debug/app
+    edition_check
     popd
 
     popd
@@ -72,14 +81,21 @@ main() {
     pushd app
     diff app.vector_table.objdump \
          <(cargo objdump --bin app --release -- -s -j .vector_table)
+    edition_check
     popd
 
     # check that it builds
     pushd app2
     cargo build
+    edition_check
     popd
 
     popd
+}
+
+# checks that 2018 idioms are being used
+edition_check() {
+    RUSTFLAGS="-D rust_2018_compatibility -D rust_2018_idioms" cargo check
 }
 
 # checks that QEMU doesn't crash and that it produces no error messages

--- a/ci/smallest-no-std/Cargo.toml
+++ b/ci/smallest-no-std/Cargo.toml
@@ -1,7 +1,5 @@
-cargo-features = ["edition"] # <-
-
 [package]
-edition = "2018" # <-
+edition = "2018"
 name = "app"
 authors = ["Jorge Aparicio <jorge@japaric.io>"]
 version = "0.1.0"

--- a/ci/smallest-no-std/Cargo.toml
+++ b/ci/smallest-no-std/Cargo.toml
@@ -1,6 +1,9 @@
+cargo-features = ["edition"] # <-
+
 [package]
-authors = ["Jorge Aparicio <jorge@japaric.io>"]
+edition = "2018" # <-
 name = "app"
+authors = ["Jorge Aparicio <jorge@japaric.io>"]
 version = "0.1.0"
 
 [dependencies]

--- a/ci/smallest-no-std/src/main.rs
+++ b/ci/smallest-no-std/src/main.rs
@@ -5,6 +5,6 @@
 use core::panic::PanicInfo;
 
 #[panic_handler]
-fn panic(_panic: &PanicInfo) -> ! {
+fn panic(_panic: &PanicInfo<'_>) -> ! {
     loop {}
 }

--- a/ci/smallest-no-std/src/main.rs
+++ b/ci/smallest-no-std/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(panic_handler)]
 #![no_main]
 #![no_std]
 

--- a/src/main.md
+++ b/src/main.md
@@ -15,11 +15,11 @@ And then rename it to `rt` which stands for "runtime".
 ``` console
 $ sed -i s/app/rt/ Cargo.toml
 
-$ head -n2 Cargo.toml
+$ head -n5 Cargo.toml
 ```
 
 ``` toml
-{{#include ../ci/main/rt/Cargo.toml:1:2}}
+{{#include ../ci/main/rt/Cargo.toml:1:5}}
 ```
 
 The first change is to have the reset handler call an external `main` function:
@@ -67,6 +67,15 @@ $ cargo new --bin app
 
 $ cd app
 
+$ # again, don't forget to move the project to the 2018 edition
+$ head -n5 Cargo.toml
+```
+
+``` toml
+{{#include ../ci/main/app/Cargo.toml:1:5}}
+```
+
+``` console
 $ cargo add rt --path ../rt
 
 $ # copy over the config file that sets a default target and tweaks the linker invocation

--- a/src/main.md
+++ b/src/main.md
@@ -15,21 +15,21 @@ And then rename it to `rt` which stands for "runtime".
 ``` console
 $ sed -i s/app/rt/ Cargo.toml
 
-$ head -n5 Cargo.toml
+$ head -n4 Cargo.toml
 ```
 
 ``` toml
-{{#include ../ci/main/rt/Cargo.toml:1:5}}
+{{#include ../ci/main/rt/Cargo.toml:1:4}}
 ```
 
 The first change is to have the reset handler call an external `main` function:
 
 ``` console
-$ head -n14 src/lib.rs
+$ head -n13 src/lib.rs
 ```
 
 ``` rust
-{{#include ../ci/main/rt/src/lib.rs:1:14}}
+{{#include ../ci/main/rt/src/lib.rs:1:13}}
 ```
 
 We also drop the `#![no_main]` attribute has it has no effect on library crates.
@@ -63,19 +63,10 @@ The `rt` will take care of giving the program the right memory layout.
 ``` console
 $ cd ..
 
-$ cargo new --bin app
+$ cargo new --edition 2018 --bin app
 
 $ cd app
 
-$ # again, don't forget to move the project to the 2018 edition
-$ head -n5 Cargo.toml
-```
-
-``` toml
-{{#include ../ci/main/app/Cargo.toml:1:5}}
-```
-
-``` console
 $ cargo add rt --path ../rt
 
 $ # copy over the config file that sets a default target and tweaks the linker invocation
@@ -113,7 +104,7 @@ $ tail -n12 ../rt/src/lib.rs
 ```
 
 ``` rust
-{{#include ../ci/main/rt/src/lib.rs:26:37}}
+{{#include ../ci/main/rt/src/lib.rs:25:37}}
 ```
 
 Then the application writers can invoke it like this:
@@ -224,7 +215,7 @@ $ head -n32 ../rt/src/lib.rs
 ```
 
 ``` rust
-{{#include ../ci/main/rt2/src/lib.rs:1:32}}
+{{#include ../ci/main/rt2/src/lib.rs:1:31}}
 ```
 
 Now end users can directly and indirectly make use of `static` variables without running into

--- a/src/memory-layout.md
+++ b/src/memory-layout.md
@@ -246,12 +246,12 @@ $ lldb target/thumbv7m-none-eabi/debug/app
 (lldb) gdb-remote 3333
 Process 1 stopped
 * thread #1, stop reason = signal SIGTRAP
-    frame #0: 0x00000008 app`Reset at main.rs:23
-   20
-   21   #[panic_handler]
-   22   fn panic(_panic: &PanicInfo) -> ! {
--> 23       loop {}
-   24   }
+    frame #0: 0x00000008 app`Reset at main.rs:22
+   19
+   20   #[panic_handler]
+   21   fn panic(_panic: &PanicInfo<'_>) -> ! {
+-> 22       loop {}
+   23   }
 
 (lldb) # ^ that source is wrong; the processor is about to execute Reset; see below
 (lldb) disassemble -frame
@@ -259,8 +259,8 @@ app`Reset:
 ->  0x8 <+0>:  sub    sp, #0x4
     0xa <+2>:  movs   r0, #0x2a
     0xc <+4>:  str    r0, [sp]
-    0xe <+6>:  b      0x10                      ; <+8> at main.rs:13
-    0x10 <+8>: b      0x10                      ; <+8> at main.rs:13
+    0xe <+6>:  b      0x10                      ; <+8> at main.rs:12
+    0x10 <+8>: b      0x10                      ; <+8> at main.rs:12
 
 (lldb) # the SP has the initial value we programmed in the vector table
 (lldb) print/x $sp

--- a/src/preface.md
+++ b/src/preface.md
@@ -37,49 +37,54 @@ This book mainly targets to two audiences:
 
 ### Requirements
 
-This book is self contained. The reader doesn't need to be familiar with the Cortex-M architecture,
-nor is access to a Cortex-M microcontroller needed -- all the examples included in this book can be tested in
-QEMU. You will, however, need to install the following tools to run and inspect the examples in this
+This book is self contained. The reader doesn't need to be familiar with the
+Cortex-M architecture, nor is access to a Cortex-M microcontroller needed -- all
+the examples included in this book can be tested in QEMU. You will, however,
+need to install the following tools to run and inspect the examples in this
 book:
 
 - All the code in this book uses the 2018 edition. If you are not familiar with
-the 2018 features and idioms check [the edition guide]. Please also note that
-until the 2018 edition is officially released you'll have to *manually modify
-the Cargo.toml of new projects* to make use the 2018 edition. The required
-changes are shown below:
+  the 2018 features and idioms check [the edition guide].
 
-[the edition guide]: https://rust-lang-nursery.github.io/edition-guide/
+- Rust 1.30, 1.30-beta, nightly-2018-09-13, or a newer toolchain PLUS ARM
+  Cortex-M compilation support.
 
-``` diff
-+cargo-features = ["edition"]
-+
- [package]
-+edition = "2018"
- name = "hello"
- version = "0.1.0"
-```
-
-- A nightly toolchain from 2018-08-28 or newer.
-
-- [`cargo-binutils`](https://github.com/japaric/cargo-binutils). v0.1.2 or newer.
+- [`cargo-binutils`](https://github.com/japaric/cargo-binutils). v0.1.4 or newer.
 
 - [`cargo-edit`](https://crates.io/crates/cargo-edit).
 
-- The `thumbv7m-none-eabi` target.
+- QEMU with support for ARM emulation. The `qemu-system-arm` program must be
+  installed on your computer.
 
-- QEMU with support for ARM emulation. The `qemu-system-arm` program must be installed on your
-  computer. The name may differ for non-Debian based distributions.
+- LLDB. GDB with ARM support can also be used, but this book chooses LLDB as
+  it's more likely that readers that are not into Cortex-M development have
+  installed LLDB than GDB with ARM support.
 
-- LLDB. GDB with ARM support can also be used, but this book chooses LLDB as it's more likely that
-  readers that are not into Cortex-M development have installed LLDB than GDB with ARM support.
+#### Example setup on Ubuntu 18.04
 
-  #### Rust toolchain setup on Linux
+``` console
+$ # Rust toolchain
+$ # If you start from scratch, get rustup from https://rustup.rs/
+$ rustup default beta
 
-  ```bash
-  rustup default nightly # If you start from scratch, get rustup from https://rustup.rs/
-  rustup target add thumbv7m-none-eabi
-  cargo install cargo-binutils
-  rustup component add llvm-tools-preview
-  sudo apt-get install libssl-dev # For Debian based systems (Ubuntu)
-  cargo install cargo-edit
-  ```
+$ rustc -V
+rustc 1.30.0-beta (????????? 2018-09-1?)
+
+$ rustup target add thumbv7m-none-eabi
+
+$ # cargo-binutils
+$ cargo install cargo-binutils
+
+$ rustup component add llvm-tools-preview
+
+$ # cargo-edit
+$ sudo apt-get install gcc libssl-dev pkg-config
+
+$ cargo install cargo-edit
+
+$ # QEMU
+$ sudo apt-get install qemu-system-arm
+
+$ # LLDB
+$ sudo apt-get install lldb
+```

--- a/src/preface.md
+++ b/src/preface.md
@@ -42,6 +42,23 @@ nor is access to a Cortex-M microcontroller needed -- all the examples included 
 QEMU. You will, however, need to install the following tools to run and inspect the examples in this
 book:
 
+- All the code in this book uses the 2018 edition. If you are not familiar with
+the 2018 features and idioms check [the edition guide]. Please also note that
+until the 2018 edition is officially released you'll have to *manually modify
+the Cargo.toml of new projects* to make use the 2018 edition. The required
+changes are shown below:
+
+[the edition guide]: https://rust-lang-nursery.github.io/edition-guide/
+
+``` diff
++cargo-features = ["edition"]
++
+ [package]
++edition = "2018"
+ name = "hello"
+ version = "0.1.0"
+```
+
 - A nightly toolchain from 2018-08-28 or newer.
 
 - [`cargo-binutils`](https://github.com/japaric/cargo-binutils). v0.1.2 or newer.

--- a/src/smallest-no-std.md
+++ b/src/smallest-no-std.md
@@ -44,6 +44,15 @@ $ cargo new --bin app
 
 $ cd app
 
+$ # don't forget to move the project to the 2018 edition
+$ head -n5 Cargo.toml
+```
+
+``` toml
+{{#include ../ci/smallest-no-std/Cargo.toml:1:5}}
+```
+
+``` console
 $ # modify main.rs so it has these contents
 $ cat src/main.rs
 ```

--- a/src/smallest-no-std.md
+++ b/src/smallest-no-std.md
@@ -40,16 +40,9 @@ runs on a system. It can be many things that a standard Rust application can nev
 With that out of the way, we can move on to the smallest `#![no_std]` program that compiles:
 
 ``` console
-$ cargo new --bin app
+$ cargo new --edition 2018 --bin app
 
 $ cd app
-
-$ # don't forget to move the project to the 2018 edition
-$ head -n5 Cargo.toml
-```
-
-``` toml
-{{#include ../ci/smallest-no-std/Cargo.toml:1:5}}
 ```
 
 ``` console
@@ -77,8 +70,6 @@ indexing).
 This program doesn't produce anything useful. In fact, it will produce an empty binary.
 
 ``` console
-$ cargo rustc --target thumbv7m-none-eabi -- --emit=obj
-
 $ # equivalent to `size target/thumbv7m-none-eabi/debug/app`
 $ cargo size --target thumbv7m-none-eabi --bin app
 ```
@@ -87,7 +78,11 @@ $ cargo size --target thumbv7m-none-eabi --bin app
 {{#include ../ci/smallest-no-std/app.size}}
 ```
 
+Before linking the crate does contain the panicking symbol.
+
 ``` console
+$ cargo rustc --target thumbv7m-none-eabi -- --emit=obj
+
 $ cargo nm -- target/thumbv7m-none-eabi/debug/deps/app-*.o | grep '[0-9]* [^n] '
 ```
 


### PR DESCRIPTION
most code changes are minor

the annoying part of using the 2018 edition right now is that there is no easy
way to create new 2018 project (Cargo still defaults to 2015 projects; see
rust-lang/cargo#5980) and there's no visible documentation on how to move a new
project to the 2018 edition (see rust-lang-nursery/edition-guide#102) so I have
included the required changes in the preface -- I hope people won't miss that
part.

r? @rust-embedded/resources (anyone)

closes #1