### PR TITLE
LLDB -> GDB; +setup instructions for Windows and mac; -cargo-edit

### DIFF
--- a/ci/exceptions/app/app.objdump
+++ b/ci/exceptions/app/app.objdump
@@ -1,0 +1,113 @@
+
+app:	file format ELF32-arm-little
+
+Disassembly of section .text:
+main:
+      40:	trap
+      42:	trap
+
+Reset:
+      44:	movw	r1, #0x0
+      48:	movw	r0, #0x0
+      4c:	movt	r1, #0x2000
+      50:	movt	r0, #0x2000
+      54:	subs	r1, r1, r0
+      56:	bl	#0xd2
+      5a:	movw	r1, #0x0
+      5e:	movw	r0, #0x0
+      62:	movt	r1, #0x2000
+      66:	movt	r0, #0x2000
+      6a:	subs	r2, r1, r0
+      6c:	movw	r1, #0x0
+      70:	movt	r1, #0x0
+      74:	bl	#0x8
+      78:	bl	#-0x3c
+      7c:	trap
+
+DefaultExceptionHandler:
+      7e:	b	#-0x4 <DefaultExceptionHandler>
+
+UsageFault:
+      7f:	sub	sp, #0x19c
+
+__aeabi_memcpy:
+      80:	push	{r4, r5, r7, lr}
+      82:	cbz	r2, #0x56
+      84:	subs	r3, r2, #0x1
+      86:	and	r12, r2, #0x3
+      8a:	cmp	r3, #0x3
+      8c:	bhs	#0x8 <__aeabi_memcpy+0x18>
+      8e:	movs	r2, #0x0
+      90:	cmp.w	r12, #0x0
+      94:	bne	#0x26 <__aeabi_memcpy+0x3e>
+      96:	b	#0x42 <__aeabi_memcpy+0x5c>
+      98:	sub.w	lr, r2, r12
+      9c:	movs	r2, #0x0
+      9e:	ldrb	r3, [r1, r2]
+      a0:	adds	r4, r1, r2
+      a2:	strb	r3, [r0, r2]
+      a4:	adds	r3, r0, r2
+      a6:	adds	r2, #0x4
+      a8:	ldrb	r5, [r4, #0x1]
+      aa:	cmp	lr, r2
+      ac:	strb	r5, [r3, #0x1]
+      ae:	ldrb	r5, [r4, #0x2]
+      b0:	strb	r5, [r3, #0x2]
+      b2:	ldrb	r4, [r4, #0x3]
+      b4:	strb	r4, [r3, #0x3]
+      b6:	bne	#-0x1c <__aeabi_memcpy+0x1e>
+      b8:	cmp.w	r12, #0x0
+      bc:	beq	#0x1c <__aeabi_memcpy+0x5c>
+      be:	ldrb	r3, [r1, r2]
+      c0:	cmp.w	r12, #0x1
+      c4:	strb	r3, [r0, r2]
+      c6:	beq	#0x12 <__aeabi_memcpy+0x5c>
+      c8:	adds	r3, r2, #0x1
+      ca:	cmp.w	r12, #0x2
+      ce:	ldrb	r5, [r1, r3]
+      d0:	strb	r5, [r0, r3]
+      d2:	it	eq
+      d4:	popeq	{r4, r5, r7, pc}
+      d6:	adds	r2, #0x2
+      d8:	ldrb	r1, [r1, r2]
+      da:	strb	r1, [r0, r2]
+      dc:	pop	{r4, r5, r7, pc}
+
+__aeabi_memset:
+      de:	cmp	r1, #0x0
+      e0:	it	eq
+      e2:	bxeq	lr
+      e4:	push	{r7, lr}
+      e6:	subs	r3, r1, #0x1
+      e8:	and	r12, r1, #0x3
+      ec:	cmp	r3, #0x3
+      ee:	bhs	#0x2 <__aeabi_memset+0x16>
+      f0:	movs	r1, #0x0
+      f2:	b	#0x14 <__aeabi_memset+0x2c>
+      f4:	sub.w	lr, r1, r12
+      f8:	movs	r1, #0x0
+      fa:	strb	r2, [r0, r1]
+      fc:	adds	r3, r0, r1
+      fe:	adds	r1, #0x4
+     100:	cmp	lr, r1
+     102:	strb	r2, [r3, #0x1]
+     104:	strb	r2, [r3, #0x2]
+     106:	strb	r2, [r3, #0x3]
+     108:	bne	#-0x12 <__aeabi_memset+0x1c>
+     10a:	cmp.w	r12, #0x0
+     10e:	pop.w	{r7, lr}
+     112:	itt	ne
+     114:	strbne	r2, [r0, r1]
+     116:	cmpne.w	r12, #0x1
+     11a:	bne	#0x0 <__aeabi_memset+0x40>
+     11c:	bx	lr
+     11e:	add	r0, r1
+     120:	cmp.w	r12, #0x2
+     124:	strb	r2, [r0, #0x1]
+     126:	it	ne
+     128:	strbne	r2, [r0, #0x2]
+     12a:	bx	lr
+
+__aeabi_memclr:
+     12c:	movs	r2, #0x0
+     12e:	b.w	#-0x54 <__aeabi_memset>

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -14,7 +14,7 @@ main() {
     rustup component add llvm-tools-preview
 
     curl -LSfs https://japaric.github.io/trust/install.sh | \
-        sh -s -- --git rust-embedded/cargo-binutils --tag v0.1.2
+        sh -s -- --git rust-embedded/cargo-binutils --tag v0.1.4
 
     pip install linkchecker --user
 }

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -79,6 +79,8 @@ main() {
 
     # check that the disassembly matches
     pushd app
+    diff app.objdump \
+         <(cargo objdump --bin app --release -- -d -no-show-raw-insn -print-imm-hex)
     diff app.vector_table.objdump \
          <(cargo objdump --bin app --release -- -s -j .vector_table)
     edition_check

--- a/src/main.md
+++ b/src/main.md
@@ -67,8 +67,15 @@ $ cargo new --edition 2018 --bin app
 
 $ cd app
 
-$ cargo add rt --path ../rt
+$ # modify Cargo.toml to include the `rt` crate as a dependency
+$ tail -n2 Cargo.toml
+```
 
+``` toml
+{{#include ../ci/main/app/src/Cargo.toml:7:8}}
+```
+
+``` console
 $ # copy over the config file that sets a default target and tweaks the linker invocation
 $ cp -r ../rt/.cargo .
 

--- a/src/preface.md
+++ b/src/preface.md
@@ -1,12 +1,10 @@
 # The embedonomicon
 
-## Preface
-
 The embedonomicon walks you through the process of creating a `#![no_std]` application from scratch
 and through the iterative process of building architecture-specific functionality for Cortex-M
 microcontrollers.
 
-### Objectives
+## Objectives
 
 By reading this book you will learn
 
@@ -20,7 +18,7 @@ By reading this book you will learn
 
 - A trick to implement default functionality that can be statically overridden (no runtime cost).
 
-### Target audience
+## Target audience
 
 This book mainly targets to two audiences:
 
@@ -35,7 +33,7 @@ This book mainly targets to two audiences:
 [`msp430-rt`]: https://crates.io/crates/msp430-rt
 [`riscv-rt`]: https://crates.io/crates/riscv-rt
 
-### Requirements
+## Requirements
 
 This book is self contained. The reader doesn't need to be familiar with the
 Cortex-M architecture, nor is access to a Cortex-M microcontroller needed -- all
@@ -56,11 +54,11 @@ book:
 - QEMU with support for ARM emulation. The `qemu-system-arm` program must be
   installed on your computer.
 
-- LLDB. GDB with ARM support can also be used, but this book chooses LLDB as
-  it's more likely that readers that are not into Cortex-M development have
-  installed LLDB than GDB with ARM support.
+- GDB with ARM support.
 
-#### Example setup on Ubuntu 18.04
+### Example setup
+
+Instructions common to all OSes
 
 ``` console
 $ # Rust toolchain
@@ -77,14 +75,32 @@ $ cargo install cargo-binutils
 
 $ rustup component add llvm-tools-preview
 
-$ # cargo-edit
-$ sudo apt-get install gcc libssl-dev pkg-config
+```
 
-$ cargo install cargo-edit
+#### macOS
+
+``` console
+$ # arm-none-eabi-gdb
+$ # you may need to run `brew tap Caskroom/tap` first
+$ brew cask install gcc-arm-embedded
+
+$ # QEMU
+$ brew install qemu
+```
+
+#### Ubuntu 16.04
+
+``` console
+$ # arm-none-eabi-gdb
+$ sudo apt-get install gdb-arm-none-eabi
 
 $ # QEMU
 $ sudo apt-get install qemu-system-arm
-
-$ # LLDB
-$ sudo apt-get install lldb
 ```
+
+#### Windows
+
+- [arm-none-eabi-gdb](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads).
+  The GNU Arm Embedded Toolchain includes GDB.
+
+- [QEMU](https://www.qemu.org/download/#windows)


### PR DESCRIPTION
this commit:

- changes the debugger to GDB since Windows and macOS users reported errors with
LLDB

- adds setup instructions for Windows and macOS

- drops the cargo-edit dependency since it's used only once and lets us simplify
  the setup instructions

- adds a note regarding .cargo/config being required in section 3 since some
  people missed it while reading section 2

- removes a note about llvm-objdump not working correctly since the problem was
  fixed in cargo-binutils v0.1.4

closes #8
closes #7

r? @rust-embedded/resources (anyone)