### PR TITLE
Added missing link to edition 2018 guide

### DIFF
--- a/src/preface.md
+++ b/src/preface.md
@@ -42,7 +42,7 @@ need to install the following tools to run and inspect the examples in this
 book:
 
 - All the code in this book uses the 2018 edition. If you are not familiar with
-  the 2018 features and idioms check [the edition guide].
+  the 2018 features and idioms check the [`edition guide`].
 
 - Rust 1.30, 1.30-beta, nightly-2018-09-13, or a newer toolchain PLUS ARM
   Cortex-M compilation support.
@@ -55,6 +55,8 @@ book:
   installed on your computer.
 
 - GDB with ARM support.
+
+[`edition guide`]: https://rust-lang-nursery.github.io/edition-guide/
 
 ### Example setup
 


### PR DESCRIPTION
It looked like the link to the edition guide was missing. But it might have been intentional because the edition guide might be moved to doc.rust-lang.org later on (https://github.com/rust-lang-nursery/edition-guide/issues/76) :-)