### PR TITLE
Add `rerun-if-changed` when needed

### DIFF
--- a/ci/asm/rt/build.rs
+++ b/ci/asm/rt/build.rs
@@ -15,5 +15,8 @@ fn main() -> Result<(), Box<Error>> {
     // assemble the `asm.s` file
     Build::new().file("asm.s").compile("asm"); // <- NEW!
 
+    // rebuild if `asm.s` changed
+    println!("cargo:rerun-if-changed=asm.s"); // <- NEW!
+
     Ok(())
 }

--- a/ci/asm/rt2/build.rs
+++ b/ci/asm/rt2/build.rs
@@ -20,5 +20,8 @@ fn main() -> Result<(), Box<Error>> {
     fs::copy("librt.a", out_dir.join("librt.a"))?; // <- NEW!
     println!("cargo:rustc-link-lib=static=rt"); // <- NEW!
 
+    // rebuild if `librt.a` changed
+    println!("cargo:rerun-if-changed=librt.a"); // <- NEW!
+
     Ok(())
 }


### PR DESCRIPTION
It's needed when using assembly so it's rebuilt when changed (at least for cc, wasn't able to test the .a way)