### PR TITLE
added note for 'eh_personality' error

### DIFF
--- a/src/smallest-no-std.md
+++ b/src/smallest-no-std.md
@@ -104,3 +104,7 @@ $ cat .cargo/config
 ``` toml
 {{#include ../ci/smallest-no-std/.cargo/config}}
 ```
+
+Note: if you encountered an error `language item required, but not found: 'eh_personality'` when attempting to build 
+your project, check your `Cargo.toml` file to be both your `.dev` and `.release` profiles specify `panic = "abort"` (and
+not `panic = "unwind"`) for now.


### PR DESCRIPTION
If one happens to have a standard profile set to unwinding panics, a `language item required, but not found: 'eh_personality'` will result.  This PR adds a brief note explaining how to resolve the error.