### PR TITLE
Fix linker error in memory layout example

### DIFF
--- a/ci/memory-layout/link.x
+++ b/ci/memory-layout/link.x
@@ -29,6 +29,6 @@ SECTIONS
 
   /DISCARD/ :
   {
-    *(.ARM.exidx.*);
+    *(.ARM.exidx .ARM.exidx.*);
   }
 }


### PR DESCRIPTION
When following the example in the memory layout chapter, I found that
linking with rustc 1.39.0 (command `cargo rustc -- -C
link-arg=-Tlink.x`) produced the following error:

```
   Compiling no_std_app v0.1.0 (/home/austin/repos/personal/no_std_experiment)
error: linking with `rust-lld` failed: exit code: 1
  |
  = note: "rust-lld" "-flavor" "gnu" "-L" "/home/austin/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/thumbv7m-none-eabi/lib" "/home/austin/repos/personal/no_std_experiment/target/thumbv7m-none-eabi/debug/deps/no_std_app-1e7c0fdb8e33f523.2ohn928r55zfdn1z.rcgu.o" "-o" "/home/austin/repos/personal/no_std_experiment/target/thumbv7m-none-eabi/debug/deps/no_std_app-1e7c0fdb8e33f523" "--gc-sections" "-L" "/home/austin/repos/personal/no_std_experiment/target/thumbv7m-none-eabi/debug/deps" "-L" "/home/austin/repos/personal/no_std_experiment/target/debug/deps" "-L" "/home/austin/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/thumbv7m-none-eabi/lib" "-Bstatic" "/home/austin/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/thumbv7m-none-eabi/lib/librustc_std_workspace_core-9864ecb2f3ae85f5.rlib" "/home/austin/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/thumbv7m-none-eabi/lib/libcore-a54bcae7919f0f3f.rlib" "/home/austin/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/thumbv7m-none-eabi/lib/libcompiler_builtins-a509ea259a1bcbbf.rlib" "-Tlink.x" "-Bdynamic"
  = note: rust-lld: error: no memory region specified for section '.ARM.exidx'

error: aborting due to previous error

error: could not compile `no_std_app`.

To learn more, run the command again with --verbose.
```

This can be solved by adding `.ARM.exidx` alone (no `.*` extension) to
the `/DISCARD/` portion of `link.x`. This change should be backwards
compatible to older versions of tooling which, presumably, do not emit
the bare top-level section.

Fixes #50 