### PR TITLE
Ignore whitespace within lines when validating objdump outputs in CI

### DIFF
--- a/ci/asm/app/release.objdump
+++ b/ci/asm/app/release.objdump
@@ -1,23 +1,25 @@
 
 app:	file format ELF32-arm-little
 
+
 Disassembly of section .text:
+
 HardFault:
-	b	#-0x4 <HardFault>
+               	b	#-0x4 <HardFault>
 
 main:
-	trap
+               	trap
 
 Reset:
-	bl	#-0x6
-	trap
+               	bl	#-0x6
+               	trap
 
 DefaultExceptionHandler:
-	b	#-0x4 <DefaultExceptionHandler>
+               	b	#-0x4 <DefaultExceptionHandler>
 
 UsageFault:
- <unknown>
+               	<unknown>
 
 HardFaultTrampoline:
-	mrs	r0, msp
-	b	#-0x14 <HardFault>
+               	mrs	r0, msp
+               	b	#-0x14 <HardFault>

--- a/ci/asm/rt/link.x
+++ b/ci/asm/rt/link.x
@@ -55,7 +55,7 @@ SECTIONS
 
   /DISCARD/ :
   {
-    *(.ARM.exidx.*);
+    *(.ARM.exidx .ARM.exidx.*);
   }
 }
 

--- a/ci/exceptions/app/app.objdump
+++ b/ci/exceptions/app/app.objdump
@@ -1,113 +1,120 @@
 
 app:	file format ELF32-arm-little
 
+
 Disassembly of section .text:
+
 main:
-	trap
-	trap
+               	trap
+               	trap
 
 Reset:
-	movw	r1, #0x0
-	movw	r0, #0x0
-	movt	r1, #0x2000
-	movt	r0, #0x2000
-	subs	r1, r1, r0
-	bl	#0xd2
-	movw	r1, #0x0
-	movw	r0, #0x0
-	movt	r1, #0x2000
-	movt	r0, #0x2000
-	subs	r2, r1, r0
-	movw	r1, #0x0
-	movt	r1, #0x0
-	bl	#0x8
-	bl	#-0x3c
-	trap
+               	movw	r1, #0x0
+               	movw	r0, #0x0
+               	movt	r1, #0x2000
+               	movt	r0, #0x2000
+               	subs	r1, r1, r0
+               	bl	#0xe2
+               	movw	r1, #0x0
+               	movw	r0, #0x0
+               	movt	r1, #0x2000
+               	movt	r0, #0x2000
+               	subs	r2, r1, r0
+               	movw	r1, #0x142
+               	movt	r1, #0x0
+               	bl	#0x8
+               	bl	#-0x3c
+               	trap
 
 DefaultExceptionHandler:
-	b	#-0x4 <DefaultExceptionHandler>
+               	b	#-0x4 <DefaultExceptionHandler>
 
 UsageFault:
-	sub	sp, #0x19c
+               	blo.w	#0x2756a <_sidata+0x274ab>
 
 __aeabi_memcpy:
-	push	{r4, r5, r7, lr}
-	cbz	r2, #0x56
-	subs	r3, r2, #0x1
-	and	r12, r2, #0x3
-	cmp	r3, #0x3
-	bhs	#0x8 <__aeabi_memcpy+0x18>
-	movs	r2, #0x0
-	cmp.w	r12, #0x0
-	bne	#0x26 <__aeabi_memcpy+0x3e>
-	b	#0x42 <__aeabi_memcpy+0x5c>
-	sub.w	lr, r2, r12
-	movs	r2, #0x0
-	ldrb	r3, [r1, r2]
-	adds	r4, r1, r2
-	strb	r3, [r0, r2]
-	adds	r3, r0, r2
-	adds	r2, #0x4
-	ldrb	r5, [r4, #0x1]
-	cmp	lr, r2
-	strb	r5, [r3, #0x1]
-	ldrb	r5, [r4, #0x2]
-	strb	r5, [r3, #0x2]
-	ldrb	r4, [r4, #0x3]
-	strb	r4, [r3, #0x3]
-	bne	#-0x1c <__aeabi_memcpy+0x1e>
-	cmp.w	r12, #0x0
-	beq	#0x1c <__aeabi_memcpy+0x5c>
-	ldrb	r3, [r1, r2]
-	cmp.w	r12, #0x1
-	strb	r3, [r0, r2]
-	beq	#0x12 <__aeabi_memcpy+0x5c>
-	adds	r3, r2, #0x1
-	cmp.w	r12, #0x2
-	ldrb	r5, [r1, r3]
-	strb	r5, [r0, r3]
-	it	eq
-	popeq	{r4, r5, r7, pc}
-	adds	r2, #0x2
-	ldrb	r1, [r1, r2]
-	strb	r1, [r0, r2]
-	pop	{r4, r5, r7, pc}
+               	push	{r4, r5, r6, r7, lr}
+               	cbz	r2, #0x60
+               	subs	r3, r2, #0x1
+               	and	r12, r2, #0x3
+               	cmp	r3, #0x3
+               	bhs	#0x8 <__aeabi_memcpy+0x18>
+               	movs	r2, #0x0
+               	cmp.w	r12, #0x0
+               	bne	#0x32 <__aeabi_memcpy+0x4a>
+               	b	#0x4c <__aeabi_memcpy+0x66>
+               	sub.w	lr, r12, r2
+               	adds	r3, r1, #0x1
+               	adds	r4, r0, #0x1
+               	mvn	r2, #0x3
+               	adds	r6, r3, r2
+               	adds	r5, r4, r2
+               	adds	r2, #0x4
+               	ldrb	r7, [r6, #0x3]
+               	strb	r7, [r5, #0x3]
+               	ldrb	r7, [r6, #0x4]
+               	strb	r7, [r5, #0x4]
+               	ldrb	r7, [r6, #0x5]
+               	strb	r7, [r5, #0x5]
+               	ldrb	r6, [r6, #0x6]
+               	strb	r6, [r5, #0x6]
+               	add.w	r5, lr, r2
+               	adds	r5, #0x4
+               	bne	#-0x20 <__aeabi_memcpy+0x24>
+               	adds	r2, #0x4
+               	cmp.w	r12, #0x0
+               	beq	#0x1a <__aeabi_memcpy+0x66>
+               	ldrb	r3, [r1, r2]
+               	cmp.w	r12, #0x1
+               	strb	r3, [r0, r2]
+               	beq	#0x10 <__aeabi_memcpy+0x66>
+               	adds	r3, r2, #0x1
+               	cmp.w	r12, #0x2
+               	ldrb	r7, [r1, r3]
+               	strb	r7, [r0, r3]
+               	beq	#0x4 <__aeabi_memcpy+0x66>
+               	adds	r2, #0x2
+               	ldrb	r1, [r1, r2]
+               	strb	r1, [r0, r2]
+               	pop	{r4, r5, r6, r7, pc}
 
 __aeabi_memset:
-	cmp	r1, #0x0
-	it	eq
-	bxeq	lr
-	push	{r7, lr}
-	subs	r3, r1, #0x1
-	and	r12, r1, #0x3
-	cmp	r3, #0x3
-	bhs	#0x2 <__aeabi_memset+0x16>
-	movs	r1, #0x0
-	b	#0x14 <__aeabi_memset+0x2c>
-	sub.w	lr, r1, r12
-	movs	r1, #0x0
-	strb	r2, [r0, r1]
-	adds	r3, r0, r1
-	adds	r1, #0x4
-	cmp	lr, r1
-	strb	r2, [r3, #0x3]
-	strb	r2, [r3, #0x2]
-	strb	r2, [r3, #0x1]
-	bne	#-0x12 <__aeabi_memset+0x1c>
-	cmp.w	r12, #0x0
-	pop.w	{r7, lr}
-	itt	ne
-	strbne	r2, [r0, r1]
-	cmpne.w	r12, #0x1
-	bne	#0x0 <__aeabi_memset+0x40>
-	bx	lr
-	add	r0, r1
-	cmp.w	r12, #0x2
-	strb	r2, [r0, #0x1]
-	it	ne
-	strbne	r2, [r0, #0x2]
-	bx	lr
+               	push	{r4, lr}
+               	cmp	r1, #0x0
+               	it	eq
+               	popeq	{r4, pc}
+               	subs	r3, r1, #0x1
+               	and	r12, r1, #0x3
+               	cmp	r3, #0x3
+               	bhs	#0x2 <__aeabi_memset+0x16>
+               	movs	r1, #0x0
+               	b	#0x1e <__aeabi_memset+0x36>
+               	sub.w	lr, r12, r1
+               	adds	r1, r0, #0x1
+               	mvn	r3, #0x3
+               	adds	r4, r1, r3
+               	adds	r3, #0x4
+               	strb	r2, [r4, #0x6]
+               	strb	r2, [r4, #0x5]
+               	strb	r2, [r4, #0x4]
+               	strb	r2, [r4, #0x3]
+               	add.w	r4, lr, r3
+               	adds	r4, #0x4
+               	bne	#-0x16 <__aeabi_memset+0x20>
+               	adds	r1, r3, #0x4
+               	cmp.w	r12, #0x0
+               	itt	ne
+               	strbne	r2, [r0, r1]
+               	cmpne.w	r12, #0x1
+               	bne	#0x0 <__aeabi_memset+0x46>
+               	pop	{r4, pc}
+               	add	r0, r1
+               	cmp.w	r12, #0x2
+               	strb	r2, [r0, #0x1]
+               	it	ne
+               	strbne	r2, [r0, #0x2]
+               	pop	{r4, pc}
 
 __aeabi_memclr:
-	movs	r2, #0x0
-	b.w	#-0x54 <__aeabi_memset>
+               	movs	r2, #0x0
+               	b.w	#-0x5a <__aeabi_memset>

--- a/ci/exceptions/rt/link.x
+++ b/ci/exceptions/rt/link.x
@@ -55,7 +55,7 @@ SECTIONS
 
   /DISCARD/ :
   {
-    *(.ARM.exidx.*);
+    *(.ARM.exidx .ARM.exidx.*);
   }
 }
 

--- a/ci/logging/app2/dev.objdump
+++ b/ci/logging/app2/dev.objdump
@@ -1,2 +1,2 @@
-00000001 g     O .log		 00000001 Goodbye
-00000000 g     O .log		 00000001 Hello, world!
+00000001 g     O .log	00000001 Goodbye
+00000000 g     O .log	00000001 Hello, world!

--- a/ci/logging/app3/dev.objdump
+++ b/ci/logging/app3/dev.objdump
@@ -1,2 +1,2 @@
-00000001 g     O .log		 00000001 Goodbye
-00000000 g     O .log		 00000001 Hello, world!
+00000001 g     O .log	00000001 Goodbye
+00000000 g     O .log	00000001 Hello, world!

--- a/ci/logging/app4/dev.objdump
+++ b/ci/logging/app4/dev.objdump
@@ -1,3 +1,3 @@
-00000000 g     O .log		 00000001 Goodbye
-00000001 g     O .log		 00000001 Hello, world!
-00000001         .log		 00000000 __log_warning_start__
+00000000 g     O .log	00000001 Goodbye
+00000001 g     O .log	00000001 Hello, world!
+00000001         .log	00000000 __log_warning_start__

--- a/ci/main/app/app.objdump
+++ b/ci/main/app/app.objdump
@@ -1,14 +1,16 @@
 
 app:	file format ELF32-arm-little
 
+
 Disassembly of section .text:
+
 main:
-	sub	sp, #4
-	movs	r0, #42
-	str	r0, [sp]
-	b	#-2 <main+0x8>
-	b	#-4 <main+0x8>
+               	sub	sp, #4
+               	movs	r0, #42
+               	str	r0, [sp]
+               	b	#-2 <main+0x8>
+               	b	#-4 <main+0x8>
 
 Reset:
-	bl	#-14
-	trap
+               	bl	#-14
+               	trap

--- a/ci/main/rt/link.x
+++ b/ci/main/rt/link.x
@@ -45,6 +45,6 @@ SECTIONS
 
   /DISCARD/ :
   {
-    *(.ARM.exidx.*);
+    *(.ARM.exidx .ARM.exidx.*);
   }
 }

--- a/ci/main/rt2/link.x
+++ b/ci/main/rt2/link.x
@@ -51,6 +51,6 @@ SECTIONS
 
   /DISCARD/ :
   {
-    *(.ARM.exidx.*);
+    *(.ARM.exidx .ARM.exidx.*);
   }
 }

--- a/ci/memory-layout/app.text.objdump
+++ b/ci/memory-layout/app.text.objdump
@@ -1,10 +1,12 @@
 
 app:	file format ELF32-arm-little
 
+
 Disassembly of section .text:
+
 Reset:
-	sub	sp, #4
-	movs	r0, #42
-	str	r0, [sp]
-	b	#-2 <Reset+0x8>
-	b	#-4 <Reset+0x8>
+               	sub	sp, #4
+               	movs	r0, #42
+               	str	r0, [sp]
+               	b	#-2 <Reset+0x8>
+               	b	#-4 <Reset+0x8>

--- a/ci/memory-layout/link.x
+++ b/ci/memory-layout/link.x
@@ -29,6 +29,6 @@ SECTIONS
 
   /DISCARD/ :
   {
-    *(.ARM.exidx.*);
+    *(.ARM.exidx .ARM.exidx.*);
   }
 }

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,5 +1,14 @@
 set -euxo pipefail
 
+# All objdumps are compared to their expected output using the `-b` flag, which
+# ignores whitespace changes within lines. This is good to avoid the necessity
+# of regenerating blessed outputs each time `cargo objdump` makes minor
+# formatting changes.
+#
+# Note that `diff -b` does _not_ allow whitespace changes to span multiple
+# lines (i.e. the addition or removal of whitespace-only lines). This is a good
+# thing, since some files are included in the book based on line number.
+
 main() {
     # build the book and check that it has no dead links
     mdbook build
@@ -41,11 +50,11 @@ main() {
     pushd memory-layout
 
     # check that the Reset symbol is there
-    diff app.text.objdump \
+    diff -b app.text.objdump \
          <(cargo objdump --bin app -- -d -no-show-raw-insn -no-leading-addr)
 
     # check that the reset vector is there and has the right address
-    diff app.vector_table.objdump \
+    diff -b app.vector_table.objdump \
          <(cargo objdump --bin app -- -s -section .vector_table)
 
     qemu_check target/thumbv7m-none-eabi/debug/app
@@ -59,7 +68,7 @@ main() {
 
     # check that the disassembly matches
     pushd app
-    diff app.objdump \
+    diff -b app.objdump \
          <(cargo objdump --bin app -- -d -no-show-raw-insn -no-leading-addr)
     # disabled because of rust-lang/rust#53964
     # edition_check
@@ -94,9 +103,9 @@ main() {
 
         # check that the disassembly matches
         pushd app
-        diff app.objdump \
+        diff -b app.objdump \
              <(cargo objdump --bin app --release -- -d -no-show-raw-insn -print-imm-hex -no-leading-addr)
-        diff app.vector_table.objdump \
+        diff -b app.vector_table.objdump \
              <(cargo objdump --bin app --release -- -s -j .vector_table)
         edition_check
         popd
@@ -115,7 +124,7 @@ main() {
 
     # check that the disassembly matches
     pushd app
-    diff release.objdump \
+    diff -b release.objdump \
          <(cargo objdump --bin app --release -- -d -no-show-raw-insn -print-imm-hex -no-leading-addr)
     diff release.vector_table \
          <(cargo objdump --bin app --release -- -s -j .vector_table)
@@ -126,13 +135,13 @@ main() {
     pushd rt2
     arm-none-eabi-as -march=armv7-m asm.s -o asm.o
     ar crs librt.a asm.o
-    diff librt.objdump \
+    diff -b librt.objdump \
          <(arm-none-eabi-objdump -Cd librt.a)
     popd
 
     # check that the disassembly matches
     pushd app2
-    diff release.objdump \
+    diff -b release.objdump \
          <(cargo objdump --bin app --release -- -d -no-show-raw-insn -print-imm-hex -no-leading-addr)
     diff release.vector_table \
          <(cargo objdump --bin app --release -- -s -j .vector_table)
@@ -180,7 +189,7 @@ main() {
     pushd app2
     diff dev.out \
          <(cargo run | xxd -p)
-    diff dev.objdump \
+    diff -b dev.objdump \
          <(cargo objdump --bin app -- -t | grep '\.log')
     edition_check
     popd
@@ -189,7 +198,7 @@ main() {
     pushd app3
     diff dev.out \
          <(cargo run | xxd -p)
-    diff dev.objdump \
+    diff -b dev.objdump \
          <(cargo objdump --bin app -- -t | grep '\.log')
     edition_check
     popd
@@ -198,7 +207,7 @@ main() {
     pushd app4
     diff dev.out \
          <(cargo run | xxd -p)
-    diff dev.objdump \
+    diff -b dev.objdump \
          <(cargo objdump --bin app -- -t | grep '\.log')
     edition_check
     popd
@@ -211,9 +220,9 @@ main() {
     pushd app
     diff dev.out \
          <(cargo run | xxd -p)
-    diff dev.objdump \
+    diff -b dev.objdump \
          <(cargo objdump --bin app -- -t | grep '\.log')
-    diff release.objdump \
+    diff -b release.objdump \
          <(cargo objdump --bin app --release -- -t | grep LOGGER)
     edition_check
     popd

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -31,7 +31,7 @@ main() {
 
     # check presence of the `rust_begin_unwind` symbol
     diff app.o.nm \
-         <(cargo nm -- target/thumbv7m-none-eabi/debug/deps/app-*.o | grep '[0-9]* [^n] ')
+         <(cargo nm -- target/thumbv7m-none-eabi/debug/deps/app-*.o | grep '[0-9]* [^N] ')
 
     edition_check
 

--- a/ci/singleton/app/dev.objdump
+++ b/ci/singleton/app/dev.objdump
@@ -1,2 +1,2 @@
-00000001 g     O .log		 00000001 Goodbye
-00000000 g     O .log		 00000001 Hello, world!
+00000001 g     O .log	00000001 Goodbye
+00000000 g     O .log	00000001 Hello, world!

--- a/src/exceptions.md
+++ b/src/exceptions.md
@@ -149,7 +149,7 @@ $ cargo objdump --bin app --release -- -d -no-show-raw-insn -print-imm-hex
 ```
 
 ``` text
-{{#include ../ci/exceptions/app/app.objdump:1:28}}
+{{#include ../ci/exceptions/app/app.objdump:1:30}}
 ```
 
 ``` console

--- a/src/smallest-no-std.md
+++ b/src/smallest-no-std.md
@@ -83,7 +83,7 @@ Before linking the crate does contain the panicking symbol.
 ``` console
 $ cargo rustc --target thumbv7m-none-eabi -- --emit=obj
 
-$ cargo nm -- target/thumbv7m-none-eabi/debug/deps/app-*.o | grep '[0-9]* [^n] '
+$ cargo nm -- target/thumbv7m-none-eabi/debug/deps/app-*.o | grep '[0-9]* [^N] '
 ```
 
 ``` text


### PR DESCRIPTION
Closes #55 

Based at #54 

If the output of `cargo objdump` changes only with regard to whitespace, it's probably OK to still pass CI. Most readers probably won't even notice whitespace differences in the first place.

The [`diff` documentation](https://www.gnu.org/software/diffutils/manual/html_node/White-Space.html#White-Space) says of whitespace-suppressing options:

> The --ignore-space-change (-b) option is stronger than -E and -Z combined. It ignores white space at line end, and considers all other sequences of one or more white space characters within a line to be equivalent.

This ignores only changes _within_ a line -- changes which span multiple lines (i.e. the addition or removal of whitespace-only lines) will still compare as different. This is a good thing, because there are places the book includes a subset of a file based on line numbers.
