### PR TITLE
Fix warnings in build scripts and examples

### DIFF
--- a/ci/asm/rt/build.rs
+++ b/ci/asm/rt/build.rs
@@ -2,7 +2,7 @@ use std::{env, error::Error, fs::File, io::Write, path::PathBuf};
 
 use cc::Build;
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     // build directory for this crate
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 

--- a/ci/asm/rt2/build.rs
+++ b/ci/asm/rt2/build.rs
@@ -6,7 +6,7 @@ use std::{
     path::PathBuf,
 };
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     // build directory for this crate
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 

--- a/ci/logging/app/src/main.rs
+++ b/ci/logging/app/src/main.rs
@@ -14,12 +14,12 @@ fn main() -> ! {
     #[export_name = "Hello, world!"]
     static A: u8 = 0;
 
-    writeln!(hstdout, "{:#x}", &A as *const u8 as usize);
+    let _ = writeln!(hstdout, "{:#x}", &A as *const u8 as usize);
 
     #[export_name = "Goodbye"]
     static B: u8 = 0;
 
-    writeln!(hstdout, "{:#x}", &B as *const u8 as usize);
+    let _ = writeln!(hstdout, "{:#x}", &B as *const u8 as usize);
 
     debug::exit(debug::EXIT_SUCCESS);
 

--- a/ci/logging/app3/src/main.rs
+++ b/ci/logging/app3/src/main.rs
@@ -27,9 +27,9 @@ fn main() -> ! {
     let hstdout = hio::hstdout().unwrap();
     let mut logger = Logger { hstdout };
 
-    log!(logger, "Hello, world!");
+    let _ = log!(logger, "Hello, world!");
 
-    log!(logger, "Goodbye");
+    let _ = log!(logger, "Goodbye");
 
     debug::exit(debug::EXIT_SUCCESS);
 

--- a/ci/logging/app4/src/main.rs
+++ b/ci/logging/app4/src/main.rs
@@ -15,9 +15,9 @@ fn main() -> ! {
     let hstdout = hio::hstdout().unwrap();
     let mut logger = Logger { hstdout };
 
-    warn!(logger, "Hello, world!"); // <- CHANGED!
+    let _ = warn!(logger, "Hello, world!"); // <- CHANGED!
 
-    error!(logger, "Goodbye"); // <- CHANGED!
+    let _ = error!(logger, "Goodbye"); // <- CHANGED!
 
     debug::exit(debug::EXIT_SUCCESS);
 

--- a/ci/logging/log/build.rs
+++ b/ci/logging/log/build.rs
@@ -1,6 +1,6 @@
 use std::{env, error::Error, fs::File, io::Write, path::PathBuf};
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     // Put the linker script somewhere the linker can find it
     let out = PathBuf::from(env::var("OUT_DIR")?);
 

--- a/ci/main/rt/build.rs
+++ b/ci/main/rt/build.rs
@@ -1,6 +1,6 @@
 use std::{env, error::Error, fs::File, io::Write, path::PathBuf};
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     // build directory for this crate
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 


### PR DESCRIPTION
Fixes #57 

The build scripts were missing `dyn` on the boxed error type; fixing those is a no-brainer.

Additionally, there were warnings about unused `Result`s in the logging apps. I chose to explicitly ignore them (preserving the precise behavior which before had been implicit). But there might be an argument for `unwrap`ing them instead, or demonstrating more idiomatic error-handling.

In any case, it may be worth adding some discussion about how error handling is basically being ignored here in favor of communicating other concepts. Apologies if it's already there - I'm still working through the book myself.

Would anyone be interested in a section on idiomatic error handling in embedded rust? Is that a better fit for the embedded book rather than the embedonomicon? I'll admit that I don't really know much about this topic myself yet, but I'm interested to learn, and I'd be happy to strike up a dialogue with some folks who do have ideas there, do some drafting, and get some feedback/editing. If anyone's interested in this I'll open a separate issue to discuss in more depth.