### PR TITLE
dma: Mention store-buffer reordering on Cortex-M7

### DIFF
--- a/src/dma.md
+++ b/src/dma.md
@@ -234,7 +234,8 @@ starting a DMA transaction.
 
 In the case of Cortex-M7 cores you'll need memory barriers (DMB/DSB) if you are
 using the data cache (DCache), unless you manually invalidate the buffer used by
-the DMA.
+the DMA. Even with the data cache disabled, memory barriers might still be
+required to avoid reordering in the store buffer.
 
 If your target is a multi-core system then it's very likely that you'll need
 memory barriers.


### PR DESCRIPTION
The section on memory barrier requirements for DMA previously suggested that memory barriers are only required when using the data cache. This is not the complete story, as reordering can still occur in the write buffer.

The details will depend on how the involved memory is marked (Normal/Device/…), but a common case where barriers will be needed on e.g. a STM32H7x3-series chip is when interfacing with the Ethernet DMA engine. Even if the dcache is disabled, a barrier will be needed before updating the DMA tail pointer to ensure the driver's writes to the newly-queued packet buffer and buffer descriptor will be seen by the hardware.

I'm not sure whether a more thorough explanation would be in scope here, since it depends on platform details, but with this change, readers are at least made aware of the issue. (We recently stumbled over this in an open-source hardware/software project, see https://github.com/quartiq/stabilizer/issues/33.)