### PR TITLE
Typo in cargo objdump argument

### DIFF
--- a/src/memory-layout.md
+++ b/src/memory-layout.md
@@ -216,7 +216,7 @@ This is the disassembly of the `.text` section. We see that the reset handler, n
 located at address `0x8`.
 
 ``` console
-$ cargo objdump --bin app -- -s -section .vector_table
+$ cargo objdump --bin app -- -s --section .vector_table
 ```
 
 ``` text


### PR DESCRIPTION
Found a small typo in `memory-layout.md`
``` console
cargo objdump --bin app -- -s -section .vector_table
```

should read
``` console
cargo objdump --bin app -- -s --section .vector_table
```