### PR TITLE
Fix CI: regenerate known-good outputs with latest Rust nightly

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -3,5 +3,5 @@ delete_merged_branches = true
 required_approvals = 1
 status = [
     "build (stable)",
-    "build (1.51.0)",
+    "build (1.58.1)",
 ]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.51.0  # Minimum supported rust version (MSRV)
+          - 1.58.1  # Minimum supported rust version (MSRV)
         include:
           - rust: nightly
             experimental: true

--- a/ci/asm/app/release.objdump
+++ b/ci/asm/app/release.objdump
@@ -1,24 +1,23 @@
 
 app:	file format elf32-littlearm
 
-
 Disassembly of section .text:
 
 <HardFault>:
-               	b	#-0x4 <HardFault>
+               	b	0x40 <HardFault>        @ imm = #-0x4
 
 <main>:
-               	b	#-0x4 <main>
+               	b	0x42 <main>             @ imm = #-0x4
 
 <Reset>:
                	push	{r7, lr}
                	mov	r7, sp
-               	bl	#-0xa
+               	bl	0x42 <main>             @ imm = #-0xa
                	trap
 
 <UsageFault>:
-               	b	#-0x4 <UsageFault>
+               	b	0x4e <UsageFault>       @ imm = #-0x4
 
 <HardFaultTrampoline>:
                	mrs	r0, msp
-               	b	#-0x18 <HardFault>
+               	b	0x40 <HardFault>        @ imm = #-0x18

--- a/ci/asm/app/release.vector_table
+++ b/ci/asm/app/release.vector_table
@@ -1,6 +1,5 @@
 
 app:	file format elf32-littlearm
-
 Contents of section .vector_table:
  0000 00000120 45000000 4f000000 51000000  ... E...O...Q...
  0010 4f000000 4f000000 4f000000 00000000  O...O...O.......

--- a/ci/exceptions/app/app.objdump
+++ b/ci/exceptions/app/app.objdump
@@ -15,44 +15,50 @@ Disassembly of section .text:
                	movt	r1, #0x2000
                	movt	r0, #0x2000
                	subs	r1, r1, r0
-               	bl	0x92 <__aeabi_memclr>   @ imm = #0x34
+               	bl	0x84 <__aeabi_memclr>   @ imm = #0x26
                	movw	r1, #0x0
                	movw	r0, #0x0
                	movt	r1, #0x2000
                	movt	r0, #0x2000
                	subs	r2, r1, r0
-               	movw	r1, #0x280
+               	movw	r1, #0x288
                	movt	r1, #0x0
-               	bl	0x84 <__aeabi_memcpy>   @ imm = #0x8
+               	bl	0x88 <__aeabi_memcpy>   @ imm = #0xc
                	bl	0x40 <main>             @ imm = #-0x40
                	trap
 
 <UsageFault>:
                	b	0x82 <UsageFault>       @ imm = #-0x4
 
-<__aeabi_memcpy>:
-               	b.w	0x98 <memcpy>           @ imm = #0x10
+<__aeabi_memclr>:
+               	b.w	0x9a <compiler_builtins::arm::__aeabi_memclr::h96ee28dc2b586447> @ imm = #0x12
 
-<__aeabi_memset>:
+<__aeabi_memcpy>:
+               	b.w	0x8c <compiler_builtins::arm::__aeabi_memcpy::hf6d647cdc92d542c> @ imm = #0x0
+
+<compiler_builtins::arm::__aeabi_memcpy::hf6d647cdc92d542c>:
+               	b.w	0xa0 <compiler_builtins::mem::memcpy::hac255b7467641344> @ imm = #0x10
+
+<compiler_builtins::arm::__aeabi_memset::haf82f618eda1ab58>:
                	mov	r3, r1
                	mov	r1, r2
                	mov	r2, r3
-               	b.w	0x1e4 <memset>          @ imm = #0x152
+               	b.w	0x1ec <compiler_builtins::mem::memset::h1dd8afbc6e8f8510> @ imm = #0x152
 
-<__aeabi_memclr>:
+<compiler_builtins::arm::__aeabi_memclr::h96ee28dc2b586447>:
                	movs	r2, #0x0
-               	b.w	0x88 <__aeabi_memset>   @ imm = #-0x10
+               	b.w	0x90 <compiler_builtins::arm::__aeabi_memset::haf82f618eda1ab58> @ imm = #-0x10
 
-<memcpy>:
+<compiler_builtins::mem::memcpy::hac255b7467641344>:
                	push	{r4, r5, r6, r7, lr}
                	add	r7, sp, #0xc
                	push.w	{r8, r9, r10}
                	cmp	r2, #0xf
-               	bls	0x16c <memcpy+0xd4>     @ imm = #0xc6
+               	bls	0x174 <compiler_builtins::mem::memcpy::hac255b7467641344+0xd4> @ imm = #0xc6
                	rsbs	r3, r0, #0
                	ands	r4, r3, #0x3
                	add.w	r12, r0, r4
-               	beq	0xde <memcpy+0x46>      @ imm = #0x2c
+               	beq	0xe6 <compiler_builtins::mem::memcpy::hac255b7467641344+0x46> @ imm = #0x2c
                	mov	r3, r0
                	mov	r6, r1
                	ldrb	r5, [r6]
@@ -66,20 +72,20 @@ Disassembly of section .text:
                	itt	lo
                	strblo	r5, [r3], #1
                	cmplo	r3, r12
-               	bhs	0xde <memcpy+0x46>      @ imm = #0xa
+               	bhs	0xe6 <compiler_builtins::mem::memcpy::hac255b7467641344+0x46> @ imm = #0xa
                	ldrb	r5, [r6, #0x3]
                	adds	r6, #0x4
                	strb	r5, [r3], #1
                	cmp	r3, r12
-               	blo	0xb4 <memcpy+0x1c>      @ imm = #-0x2c
+               	blo	0xbc <compiler_builtins::mem::memcpy::hac255b7467641344+0x1c> @ imm = #-0x2c
                	sub.w	lr, r2, r4
                	add.w	r9, r1, r4
                	bic	r8, lr, #0x3
                	add.w	r3, r12, r8
                	lsls.w	r2, r9, #0x1e
-               	beq	0x174 <memcpy+0xdc>     @ imm = #0x7e
+               	beq	0x17c <compiler_builtins::mem::memcpy::hac255b7467641344+0xdc> @ imm = #0x7e
                	cmp.w	r8, #0x1
-               	blt	0x1a6 <memcpy+0x10e>    @ imm = #0xaa
+               	blt	0x1ae <compiler_builtins::mem::memcpy::hac255b7467641344+0x10e> @ imm = #0xaa
                	movs	r2, #0x18
                	and.w	r10, r2, r9, lsl #3
                	movs	r2, #0x0
@@ -94,7 +100,7 @@ Disassembly of section .text:
                	orrs	r1, r4
                	str	r1, [r12], #4
                	cmp	r12, r3
-               	bhs	0x1a6 <memcpy+0x10e>    @ imm = #0x7a
+               	bhs	0x1ae <compiler_builtins::mem::memcpy::hac255b7467641344+0x10e> @ imm = #0x7a
                	lsr.w	r1, r2, r10
                	ldr	r2, [r6]
                	lsl.w	r4, r2, r5
@@ -109,7 +115,7 @@ Disassembly of section .text:
                	itt	lo
                	strlo	r1, [r12], #4
                	cmplo	r12, r3
-               	bhs	0x1a6 <memcpy+0x10e>    @ imm = #0x50
+               	bhs	0x1ae <compiler_builtins::mem::memcpy::hac255b7467641344+0x10e> @ imm = #0x50
                	lsr.w	r1, r2, r10
                	ldr	r2, [r6, #0x8]
                	adds	r6, #0x10
@@ -117,14 +123,14 @@ Disassembly of section .text:
                	orrs	r1, r4
                	str	r1, [r12], #4
                	cmp	r12, r3
-               	blo	0x114 <memcpy+0x7c>     @ imm = #-0x58
-               	b	0x1a6 <memcpy+0x10e>    @ imm = #0x38
+               	blo	0x11c <compiler_builtins::mem::memcpy::hac255b7467641344+0x7c> @ imm = #-0x58
+               	b	0x1ae <compiler_builtins::mem::memcpy::hac255b7467641344+0x10e> @ imm = #0x38
                	mov	r3, r0
                	cmp	r2, #0x1
-               	bge	0x1b2 <memcpy+0x11a>    @ imm = #0x3e
-               	b	0x1de <memcpy+0x146>    @ imm = #0x68
+               	bge	0x1ba <compiler_builtins::mem::memcpy::hac255b7467641344+0x11a> @ imm = #0x3e
+               	b	0x1e6 <compiler_builtins::mem::memcpy::hac255b7467641344+0x146> @ imm = #0x68
                	cmp.w	r8, #0x1
-               	blt	0x1a6 <memcpy+0x10e>    @ imm = #0x2a
+               	blt	0x1ae <compiler_builtins::mem::memcpy::hac255b7467641344+0x10e> @ imm = #0x2a
                	mov	r4, r9
                	ldr	r1, [r4]
                	str	r1, [r12], #4
@@ -137,16 +143,16 @@ Disassembly of section .text:
                	itt	lo
                	strlo	r1, [r12], #4
                	cmplo	r12, r3
-               	bhs	0x1a6 <memcpy+0x10e>    @ imm = #0xa
+               	bhs	0x1ae <compiler_builtins::mem::memcpy::hac255b7467641344+0x10e> @ imm = #0xa
                	ldr	r1, [r4, #0xc]
                	adds	r4, #0x10
                	str	r1, [r12], #4
                	cmp	r12, r3
-               	blo	0x17c <memcpy+0xe4>     @ imm = #-0x2c
+               	blo	0x184 <compiler_builtins::mem::memcpy::hac255b7467641344+0xe4> @ imm = #-0x2c
                	add.w	r1, r9, r8
                	and	r2, lr, #0x3
                	cmp	r2, #0x1
-               	blt	0x1de <memcpy+0x146>    @ imm = #0x2a
+               	blt	0x1e6 <compiler_builtins::mem::memcpy::hac255b7467641344+0x146> @ imm = #0x2a
                	add	r2, r3
                	ldrb	r6, [r1]
                	strb	r6, [r3], #1
@@ -159,24 +165,24 @@ Disassembly of section .text:
                	itt	lo
                	strblo	r6, [r3], #1
                	cmplo	r3, r2
-               	bhs	0x1de <memcpy+0x146>    @ imm = #0xa
+               	bhs	0x1e6 <compiler_builtins::mem::memcpy::hac255b7467641344+0x146> @ imm = #0xa
                	ldrb	r6, [r1, #0x3]
                	adds	r1, #0x4
                	strb	r6, [r3], #1
                	cmp	r3, r2
-               	blo	0x1b4 <memcpy+0x11c>    @ imm = #-0x2c
+               	blo	0x1bc <compiler_builtins::mem::memcpy::hac255b7467641344+0x11c> @ imm = #-0x2c
                	pop.w	{r8, r9, r10}
                	pop	{r4, r5, r6, r7, pc}
 
-<memset>:
+<compiler_builtins::mem::memset::h1dd8afbc6e8f8510>:
                	push	{r4, r6, r7, lr}
                	add	r7, sp, #0x8
                	cmp	r2, #0xf
-               	bls	0x258 <memset+0x74>     @ imm = #0x6a
+               	bls	0x260 <compiler_builtins::mem::memset::h1dd8afbc6e8f8510+0x74> @ imm = #0x6a
                	rsbs	r3, r0, #0
                	ands	lr, r3, #0x3
                	add.w	r12, r0, lr
-               	beq	0x218 <memset+0x34>     @ imm = #0x1e
+               	beq	0x220 <compiler_builtins::mem::memset::h1dd8afbc6e8f8510+0x34> @ imm = #0x1e
                	mov	r3, r0
                	strb	r1, [r3], #1
                	cmp	r3, r12
@@ -185,15 +191,15 @@ Disassembly of section .text:
                	cmplo	r3, r12
                	strblo	r1, [r3], #1
                	cmplo	r3, r12
-               	bhs	0x218 <memset+0x34>     @ imm = #0x6
+               	bhs	0x220 <compiler_builtins::mem::memset::h1dd8afbc6e8f8510+0x34> @ imm = #0x6
                	strb	r1, [r3], #1
                	cmp	r3, r12
-               	blo	0x1fa <memset+0x16>     @ imm = #-0x20
+               	blo	0x202 <compiler_builtins::mem::memset::h1dd8afbc6e8f8510+0x16> @ imm = #-0x20
                	sub.w	lr, r2, lr
                	bic	r2, lr, #0x3
                	add.w	r3, r12, r2
                	cmp	r2, #0x1
-               	blt	0x24e <memset+0x6a>     @ imm = #0x24
+               	blt	0x256 <compiler_builtins::mem::memset::h1dd8afbc6e8f8510+0x6a> @ imm = #0x24
                	uxtb	r2, r1
                	mov.w	r4, #0x1010101
                	muls	r2, r4, r2
@@ -204,17 +210,17 @@ Disassembly of section .text:
                	cmplo	r12, r3
                	strlo	r2, [r12], #4
                	cmplo	r12, r3
-               	bhs	0x24e <memset+0x6a>     @ imm = #0x6
+               	bhs	0x256 <compiler_builtins::mem::memset::h1dd8afbc6e8f8510+0x6a> @ imm = #0x6
                	str	r2, [r12], #4
                	cmp	r12, r3
-               	blo	0x230 <memset+0x4c>     @ imm = #-0x20
+               	blo	0x238 <compiler_builtins::mem::memset::h1dd8afbc6e8f8510+0x4c> @ imm = #-0x20
                	and	r2, lr, #0x3
                	cmp	r2, #0x1
-               	bge	0x25e <memset+0x7a>     @ imm = #0x6
-               	b	0x27e <memset+0x9a>     @ imm = #0x24
+               	bge	0x266 <compiler_builtins::mem::memset::h1dd8afbc6e8f8510+0x7a> @ imm = #0x6
+               	b	0x286 <compiler_builtins::mem::memset::h1dd8afbc6e8f8510+0x9a> @ imm = #0x24
                	mov	r3, r0
                	cmp	r2, #0x1
-               	blt	0x27e <memset+0x9a>     @ imm = #0x1e
+               	blt	0x286 <compiler_builtins::mem::memset::h1dd8afbc6e8f8510+0x9a> @ imm = #0x1e
                	add	r2, r3
                	strb	r1, [r3], #1
                	cmp	r3, r2
@@ -223,8 +229,8 @@ Disassembly of section .text:
                	cmplo	r3, r2
                	strblo	r1, [r3], #1
                	cmplo	r3, r2
-               	bhs	0x27e <memset+0x9a>     @ imm = #0x6
+               	bhs	0x286 <compiler_builtins::mem::memset::h1dd8afbc6e8f8510+0x9a> @ imm = #0x6
                	strb	r1, [r3], #1
                	cmp	r3, r2
-               	blo	0x260 <memset+0x7c>     @ imm = #-0x20
+               	blo	0x268 <compiler_builtins::mem::memset::h1dd8afbc6e8f8510+0x7c> @ imm = #-0x20
                	pop	{r4, r6, r7, pc}

--- a/ci/exceptions/app/app.objdump
+++ b/ci/exceptions/app/app.objdump
@@ -1,7 +1,6 @@
 
 app:	file format elf32-littlearm
 
-
 Disassembly of section .text:
 
 <main>:
@@ -16,118 +15,216 @@ Disassembly of section .text:
                	movt	r1, #0x2000
                	movt	r0, #0x2000
                	subs	r1, r1, r0
-               	bl	#0x34
+               	bl	0x92 <__aeabi_memclr>   @ imm = #0x34
                	movw	r1, #0x0
                	movw	r0, #0x0
                	movt	r1, #0x2000
                	movt	r0, #0x2000
                	subs	r2, r1, r0
-               	movw	r1, #0x16c
+               	movw	r1, #0x280
                	movt	r1, #0x0
-               	bl	#0x8
-               	bl	#-0x40
+               	bl	0x84 <__aeabi_memcpy>   @ imm = #0x8
+               	bl	0x40 <main>             @ imm = #-0x40
                	trap
 
 <UsageFault>:
-               	b	#-0x4 <UsageFault>
+               	b	0x82 <UsageFault>       @ imm = #-0x4
 
 <__aeabi_memcpy>:
-               	b.w	#0x10 <memcpy>
+               	b.w	0x98 <memcpy>           @ imm = #0x10
 
 <__aeabi_memset>:
                	mov	r3, r1
                	mov	r1, r2
                	mov	r2, r3
-               	b.w	#0x84 <memset>
+               	b.w	0x1e4 <memset>          @ imm = #0x152
 
 <__aeabi_memclr>:
                	movs	r2, #0x0
-               	b.w	#-0x10 <__aeabi_memset>
+               	b.w	0x88 <__aeabi_memset>   @ imm = #-0x10
 
 <memcpy>:
                	push	{r4, r5, r6, r7, lr}
                	add	r7, sp, #0xc
-               	str	r8, [sp, #-4]!
-               	cbz	r2, #0x10
-               	subs	r3, r2, #0x1
-               	and	r12, r2, #0x3
-               	cmp	r3, #0x3
-               	bhs	#0xc <memcpy+0x22>
+               	push.w	{r8, r9, r10}
+               	cmp	r2, #0xf
+               	bls	0x16c <memcpy+0xd4>     @ imm = #0xc6
+               	rsbs	r3, r0, #0
+               	ands	r4, r3, #0x3
+               	add.w	r12, r0, r4
+               	beq	0xde <memcpy+0x46>      @ imm = #0x2c
+               	mov	r3, r0
+               	mov	r6, r1
+               	ldrb	r5, [r6]
+               	strb	r5, [r3], #1
+               	cmp	r3, r12
+               	itttt	lo
+               	ldrblo	r5, [r6, #0x1]
+               	strblo	r5, [r3], #1
+               	cmplo	r3, r12
+               	ldrblo	r5, [r6, #0x2]
+               	itt	lo
+               	strblo	r5, [r3], #1
+               	cmplo	r3, r12
+               	bhs	0xde <memcpy+0x46>      @ imm = #0xa
+               	ldrb	r5, [r6, #0x3]
+               	adds	r6, #0x4
+               	strb	r5, [r3], #1
+               	cmp	r3, r12
+               	blo	0xb4 <memcpy+0x1c>      @ imm = #-0x2c
+               	sub.w	lr, r2, r4
+               	add.w	r9, r1, r4
+               	bic	r8, lr, #0x3
+               	add.w	r3, r12, r8
+               	lsls.w	r2, r9, #0x1e
+               	beq	0x174 <memcpy+0xdc>     @ imm = #0x7e
+               	cmp.w	r8, #0x1
+               	blt	0x1a6 <memcpy+0x10e>    @ imm = #0xaa
+               	movs	r2, #0x18
+               	and.w	r10, r2, r9, lsl #3
                	movs	r2, #0x0
-               	cmp.w	r12, #0x0
-               	bne	#0x3e <memcpy+0x5c>
-               	ldr	r8, [sp], #4
-               	pop	{r4, r5, r6, r7, pc}
-               	bic	r2, r2, #0x3
-               	add.w	lr, r0, #0x1
-               	rsbs	r4, r2, #0
-               	add.w	r8, r1, #0x1
-               	mvn	r2, #0x3
-               	add.w	r6, r8, r2
-               	add.w	r5, lr, r2
-               	adds	r2, #0x4
-               	ldrb	r3, [r6, #0x3]
-               	strb	r3, [r5, #0x3]
-               	ldrb	r3, [r6, #0x4]
-               	strb	r3, [r5, #0x4]
-               	ldrb	r3, [r6, #0x5]
-               	strb	r3, [r5, #0x5]
-               	ldrb	r3, [r6, #0x6]
-               	strb	r3, [r5, #0x6]
-               	adds	r3, r4, r2
-               	adds	r3, #0x4
-               	bne	#-0x22 <memcpy+0x34>
-               	adds	r2, #0x4
-               	cmp.w	r12, #0x0
-               	beq	#-0x42 <memcpy+0x1c>
-               	ldrb	r3, [r1, r2]
-               	cmp.w	r12, #0x1
-               	strb	r3, [r0, r2]
-               	beq	#-0x4c <memcpy+0x1c>
-               	adds	r3, r2, #0x1
-               	cmp.w	r12, #0x2
-               	ldrb	r6, [r1, r3]
-               	strb	r6, [r0, r3]
-               	beq	#-0x58 <memcpy+0x1c>
-               	adds	r2, #0x2
-               	ldrb	r1, [r1, r2]
-               	strb	r1, [r0, r2]
-               	ldr	r8, [sp], #4
+               	sub.w	r2, r2, r9, lsl #3
+               	and	r5, r2, #0x18
+               	bic	r2, r9, #0x3
+               	add.w	r6, r2, #0x8
+               	ldr	r2, [r2]
+               	lsr.w	r1, r2, r10
+               	ldr	r2, [r6, #-4]
+               	lsl.w	r4, r2, r5
+               	orrs	r1, r4
+               	str	r1, [r12], #4
+               	cmp	r12, r3
+               	bhs	0x1a6 <memcpy+0x10e>    @ imm = #0x7a
+               	lsr.w	r1, r2, r10
+               	ldr	r2, [r6]
+               	lsl.w	r4, r2, r5
+               	orrs	r1, r4
+               	str	r1, [r12], #4
+               	cmp	r12, r3
+               	itttt	lo
+               	lsrlo.w	r1, r2, r10
+               	ldrlo	r2, [r6, #0x4]
+               	lsllo.w	r4, r2, r5
+               	orrlo	r1, r4
+               	itt	lo
+               	strlo	r1, [r12], #4
+               	cmplo	r12, r3
+               	bhs	0x1a6 <memcpy+0x10e>    @ imm = #0x50
+               	lsr.w	r1, r2, r10
+               	ldr	r2, [r6, #0x8]
+               	adds	r6, #0x10
+               	lsl.w	r4, r2, r5
+               	orrs	r1, r4
+               	str	r1, [r12], #4
+               	cmp	r12, r3
+               	blo	0x114 <memcpy+0x7c>     @ imm = #-0x58
+               	b	0x1a6 <memcpy+0x10e>    @ imm = #0x38
+               	mov	r3, r0
+               	cmp	r2, #0x1
+               	bge	0x1b2 <memcpy+0x11a>    @ imm = #0x3e
+               	b	0x1de <memcpy+0x146>    @ imm = #0x68
+               	cmp.w	r8, #0x1
+               	blt	0x1a6 <memcpy+0x10e>    @ imm = #0x2a
+               	mov	r4, r9
+               	ldr	r1, [r4]
+               	str	r1, [r12], #4
+               	cmp	r12, r3
+               	itttt	lo
+               	ldrlo	r1, [r4, #0x4]
+               	strlo	r1, [r12], #4
+               	cmplo	r12, r3
+               	ldrlo	r1, [r4, #0x8]
+               	itt	lo
+               	strlo	r1, [r12], #4
+               	cmplo	r12, r3
+               	bhs	0x1a6 <memcpy+0x10e>    @ imm = #0xa
+               	ldr	r1, [r4, #0xc]
+               	adds	r4, #0x10
+               	str	r1, [r12], #4
+               	cmp	r12, r3
+               	blo	0x17c <memcpy+0xe4>     @ imm = #-0x2c
+               	add.w	r1, r9, r8
+               	and	r2, lr, #0x3
+               	cmp	r2, #0x1
+               	blt	0x1de <memcpy+0x146>    @ imm = #0x2a
+               	add	r2, r3
+               	ldrb	r6, [r1]
+               	strb	r6, [r3], #1
+               	cmp	r3, r2
+               	itttt	lo
+               	ldrblo	r6, [r1, #0x1]
+               	strblo	r6, [r3], #1
+               	cmplo	r3, r2
+               	ldrblo	r6, [r1, #0x2]
+               	itt	lo
+               	strblo	r6, [r3], #1
+               	cmplo	r3, r2
+               	bhs	0x1de <memcpy+0x146>    @ imm = #0xa
+               	ldrb	r6, [r1, #0x3]
+               	adds	r1, #0x4
+               	strb	r6, [r3], #1
+               	cmp	r3, r2
+               	blo	0x1b4 <memcpy+0x11c>    @ imm = #-0x2c
+               	pop.w	{r8, r9, r10}
                	pop	{r4, r5, r6, r7, pc}
 
 <memset>:
                	push	{r4, r6, r7, lr}
                	add	r7, sp, #0x8
-               	cbz	r2, #0x3e
-               	subs	r3, r2, #0x1
-               	and	r12, r2, #0x3
-               	cmp	r3, #0x3
-               	bhs	#0x2 <memset+0x14>
-               	movs	r2, #0x0
-               	b	#0x22 <memset+0x38>
-               	bic	r2, r2, #0x3
-               	add.w	lr, r0, #0x1
-               	rsbs	r3, r2, #0
-               	mvn	r2, #0x3
-               	add.w	r4, lr, r2
-               	adds	r2, #0x4
-               	strb	r1, [r4, #0x6]
-               	strb	r1, [r4, #0x5]
-               	strb	r1, [r4, #0x4]
-               	strb	r1, [r4, #0x3]
-               	adds	r4, r3, r2
-               	adds	r4, #0x4
-               	bne	#-0x16 <memset+0x22>
-               	adds	r2, #0x4
-               	cmp.w	r12, #0x0
-               	itt	ne
-               	strbne	r1, [r0, r2]
-               	cmpne.w	r12, #0x1
-               	bne	#0x0 <memset+0x48>
-               	pop	{r4, r6, r7, pc}
-               	add	r2, r0
-               	cmp.w	r12, #0x2
-               	strb	r1, [r2, #0x1]
-               	it	ne
-               	strbne	r1, [r2, #0x2]
+               	cmp	r2, #0xf
+               	bls	0x258 <memset+0x74>     @ imm = #0x6a
+               	rsbs	r3, r0, #0
+               	ands	lr, r3, #0x3
+               	add.w	r12, r0, lr
+               	beq	0x218 <memset+0x34>     @ imm = #0x1e
+               	mov	r3, r0
+               	strb	r1, [r3], #1
+               	cmp	r3, r12
+               	itttt	lo
+               	strblo	r1, [r3], #1
+               	cmplo	r3, r12
+               	strblo	r1, [r3], #1
+               	cmplo	r3, r12
+               	bhs	0x218 <memset+0x34>     @ imm = #0x6
+               	strb	r1, [r3], #1
+               	cmp	r3, r12
+               	blo	0x1fa <memset+0x16>     @ imm = #-0x20
+               	sub.w	lr, r2, lr
+               	bic	r2, lr, #0x3
+               	add.w	r3, r12, r2
+               	cmp	r2, #0x1
+               	blt	0x24e <memset+0x6a>     @ imm = #0x24
+               	uxtb	r2, r1
+               	mov.w	r4, #0x1010101
+               	muls	r2, r4, r2
+               	str	r2, [r12], #4
+               	cmp	r12, r3
+               	itttt	lo
+               	strlo	r2, [r12], #4
+               	cmplo	r12, r3
+               	strlo	r2, [r12], #4
+               	cmplo	r12, r3
+               	bhs	0x24e <memset+0x6a>     @ imm = #0x6
+               	str	r2, [r12], #4
+               	cmp	r12, r3
+               	blo	0x230 <memset+0x4c>     @ imm = #-0x20
+               	and	r2, lr, #0x3
+               	cmp	r2, #0x1
+               	bge	0x25e <memset+0x7a>     @ imm = #0x6
+               	b	0x27e <memset+0x9a>     @ imm = #0x24
+               	mov	r3, r0
+               	cmp	r2, #0x1
+               	blt	0x27e <memset+0x9a>     @ imm = #0x1e
+               	add	r2, r3
+               	strb	r1, [r3], #1
+               	cmp	r3, r2
+               	itttt	lo
+               	strblo	r1, [r3], #1
+               	cmplo	r3, r2
+               	strblo	r1, [r3], #1
+               	cmplo	r3, r2
+               	bhs	0x27e <memset+0x9a>     @ imm = #0x6
+               	strb	r1, [r3], #1
+               	cmp	r3, r2
+               	blo	0x260 <memset+0x7c>     @ imm = #-0x20
                	pop	{r4, r6, r7, pc}

--- a/ci/exceptions/app/app.vector_table.objdump
+++ b/ci/exceptions/app/app.vector_table.objdump
@@ -1,6 +1,5 @@
 
 app:	file format elf32-littlearm
-
 Contents of section .vector_table:
  0000 00000120 45000000 83000000 83000000  ... E...........
  0010 83000000 83000000 83000000 00000000  ................

--- a/ci/logging/app2/dev.objdump
+++ b/ci/logging/app2/dev.objdump
@@ -1,2 +1,2 @@
-00000001 g     O .log	00000001 Goodbye
 00000000 g     O .log	00000001 Hello, world!
+00000001 g     O .log	00000001 Goodbye

--- a/ci/logging/app3/dev.objdump
+++ b/ci/logging/app3/dev.objdump
@@ -1,2 +1,2 @@
-00000001 g     O .log	00000001 Goodbye
 00000000 g     O .log	00000001 Hello, world!
+00000001 g     O .log	00000001 Goodbye

--- a/ci/logging/app4/dev.objdump
+++ b/ci/logging/app4/dev.objdump
@@ -1,3 +1,3 @@
-00000000 g     O .log	00000001 Goodbye
 00000001 g     O .log	00000001 Hello, world!
+00000000 g     O .log	00000001 Goodbye
 00000001 g       .log	00000000 __log_warning_start__

--- a/ci/main/app/app.objdump
+++ b/ci/main/app/app.objdump
@@ -1,18 +1,17 @@
 
 app:	file format elf32-littlearm
 
-
 Disassembly of section .text:
 
 <main>:
                	sub	sp, #4
                	movs	r0, #42
                	str	r0, [sp]
-               	b	#-2 <main+0x8>
-               	b	#-4 <main+0x8>
+               	b	0x10 <main+0x8>         @ imm = #-2
+               	b	0x10 <main+0x8>         @ imm = #-4
 
 <Reset>:
                	push	{r7, lr}
                	mov	r7, sp
-               	bl	#-18
+               	bl	0x8 <main>              @ imm = #-18
                	trap

--- a/ci/main/app4/src/main.rs
+++ b/ci/main/app4/src/main.rs
@@ -1,8 +1,7 @@
-#![feature(asm)]
 #![no_main]
 #![no_std]
 
-use core::ptr;
+use core::{ptr, arch::asm};
 
 use rt::entry;
 

--- a/ci/memory-layout/app.text.objdump
+++ b/ci/memory-layout/app.text.objdump
@@ -1,12 +1,11 @@
 
 app:	file format elf32-littlearm
 
-
 Disassembly of section .text:
 
 <Reset>:
                	sub	sp, #4
                	movs	r0, #42
                	str	r0, [sp]
-               	b	#-2 <Reset+0x8>
-               	b	#-4 <Reset+0x8>
+               	b	0x10 <Reset+0x8>        @ imm = #-2
+               	b	0x10 <Reset+0x8>        @ imm = #-4

--- a/ci/memory-layout/app.vector_table.objdump
+++ b/ci/memory-layout/app.vector_table.objdump
@@ -1,5 +1,4 @@
 
 app:	file format elf32-littlearm
-
 Contents of section .vector_table:
  0000 00000120 09000000                    ... ....

--- a/ci/singleton/app/dev.objdump
+++ b/ci/singleton/app/dev.objdump
@@ -1,2 +1,2 @@
-00000001 g     O .log	00000001 Goodbye
 00000000 g     O .log	00000001 Hello, world!
+00000001 g     O .log	00000001 Goodbye


### PR DESCRIPTION
This was a little boring! There aren't any serious changes except to the exceptions app which has changed around a bit; I haven't thoroughly checked the new assembly but don't have any reason to think it's wrong, just the result of much newer LLVM/Rust.