### PR TITLE
Adds an extra '-' to an instruction

### DIFF
--- a/src/memory-layout.md
+++ b/src/memory-layout.md
@@ -205,7 +205,7 @@ Now let's inspect the output binary to confirm the memory layout looks the way w
 (this requires [`cargo-binutils`](https://github.com/rust-embedded/cargo-binutils#readme)):
 
 ``` console
-$ cargo objdump --bin app -- -d -no-show-raw-insn
+$ cargo objdump --bin app -- -d --no-show-raw-insn
 ```
 
 ``` text


### PR DESCRIPTION
This instruction does not work
`cargo objdump --bin app -- -d -no-show-raw-insn`

Instead I had to add an extra '-' at the start of `-no-show-raw-insn`

`rustc 1.58.0-nightly`

![image](https://user-images.githubusercontent.com/8682597/159166255-308d9653-7a47-4e59-ab31-79738ce31eb2.png)
