### PR TITLE
Fix typo in md document

### DIFF
--- a/src/asm.md
+++ b/src/asm.md
@@ -89,7 +89,7 @@ by writing a very simple program.
 Here's the disassembly. Look at the address of `HardFaultTrampoline`.
 
 ``` console
-$ cargo objdump --bin app --release -- -d -no-show-raw-insn -print-imm-hex
+$ cargo objdump --bin app --release -- -d --no-show-raw-insn --print-imm-hex
 ```
 
 ``` text
@@ -178,7 +178,7 @@ Now we can test this new version against the simple program from before and
 we'll get the same output.
 
 ``` console
-$ cargo objdump --bin app --release -- -d -no-show-raw-insn -print-imm-hex
+$ cargo objdump --bin app --release -- -d --no-show-raw-insn --print-imm-hex
 ```
 
 ``` text

--- a/src/compiler-support.md
+++ b/src/compiler-support.md
@@ -20,7 +20,7 @@ following command:
 
 ``` console
 $ # you need to have `cargo-binutils` installed to run this command
-$ cargo objdump -- -version
+$ cargo objdump -- --version
 LLVM (http://llvm.org/):
   LLVM version 7.0.0svn
   Optimized build.

--- a/src/exceptions.md
+++ b/src/exceptions.md
@@ -145,7 +145,7 @@ Breakpoint 1, DefaultExceptionHandler ()
 And for completeness, here's the disassembly of the optimized version of the program:
 
 ``` console
-$ cargo objdump --bin app --release -- -d -no-show-raw-insn -print-imm-hex
+$ cargo objdump --bin app --release -- -d --no-show-raw-insn --print-imm-hex
 ```
 
 ``` text

--- a/src/main.md
+++ b/src/main.md
@@ -89,7 +89,7 @@ $ cat src/main.rs
 The disassembly will be similar but will now include the user `main` function.
 
 ``` console
-$ cargo objdump --bin app -- -d -no-show-raw-insn
+$ cargo objdump --bin app -- -d --no-show-raw-insn
 ```
 
 ``` text

--- a/src/preface.md
+++ b/src/preface.md
@@ -70,20 +70,26 @@ book:
 Instructions common to all OSes
 
 ``` console
-$ # Rust toolchain
-$ # If you start from scratch, get rustup from https://rustup.rs/
+# Rust toolchain (add +nightly for nightly rust version)
+# If you start from scratch, get rustup from https://rustup.rs/
 $ rustup default stable
+$ rustup +nightly default stable
 
-$ # toolchain should be newer than this one
+# toolchain should be newer than this one
 $ rustc -V
-rustc 1.31.0 (abe02cefd 2018-12-04)
+rustc 1.59.0 (9d1b2106e 2022-02-23)
+$ rustc +nightly -V
+rustc 1.61.0-nightly (9c06e1ba4 2022-03-29)
 
 $ rustup target add thumbv7m-none-eabi
+$ rustup +nightly target add thumbv7m-none-eabi
 
-$ # cargo-binutils
+# cargo-binutils
 $ cargo install cargo-binutils
+$ cargo +nightly install cargo-binutils
 
 $ rustup component add llvm-tools-preview
+$ rustup +nightly component add llvm-tools-preview
 
 ```
 


### PR DESCRIPTION
- Fix typo in md document, missing "-".
- Add +nightly example since examples need nightly build version.