### PR TITLE
update macos homebrew install command

### DIFF
--- a/src/preface.md
+++ b/src/preface.md
@@ -92,7 +92,7 @@ $ rustup component add llvm-tools-preview
 ``` console
 $ # arm-none-eabi-gdb
 $ # you may need to run `brew tap Caskroom/tap` first
-$ brew cask install gcc-arm-embedded
+$ brew install --cask gcc-arm-embedded
 
 $ # QEMU
 $ brew install qemu


### PR DESCRIPTION
Hi,

The brew cask command is updated. Will encounter this error when installing the tools.

```bash
$ brew cask install gcc-arm-embedded
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.
```

So this PR mainly just update that specific command for macos.