### PR TITLE
Make statics const

### DIFF
--- a/ci/main/rt2/src/lib.rs
+++ b/ci/main/rt2/src/lib.rs
@@ -8,11 +8,11 @@ pub unsafe extern "C" fn Reset() -> ! {
     // NEW!
     // Initialize RAM
     extern "C" {
-        static mut _sbss: u8;
-        static mut _ebss: u8;
+        static _sbss: u8;
+        static _ebss: u8;
 
-        static mut _sdata: u8;
-        static mut _edata: u8;
+        static _sdata: u8;
+        static _edata: u8;
         static _sidata: u8;
     }
 


### PR DESCRIPTION
With recent compiler versions we get warnings for this code where it suggests using `addr_of!` to avoid taking the intermediate reference to a static mut variable.

However, there's no clear reason why these even need to be mut. Embassy-boot doesn't use mut. So let's change it so people copying this don't get that same unhelpful warning.