### PR TITLE
Add missing binary addresses to memory layout and main chapters

### DIFF
--- a/ci/main/app/app.objdump
+++ b/ci/main/app/app.objdump
@@ -3,16 +3,16 @@ app:	file format elf32-littlearm
 
 Disassembly of section .text:
 
-<main>:
-               	push	{r7, lr}
-               	mov	r7, sp
-               	sub	sp, #0x4
-               	movs	r0, #0x2a
-               	str	r0, [sp]
-               	b	0x14 <main+0xc>         @ imm = #-0x2
-               	b	0x14 <main+0xc>         @ imm = #-0x4
+00000008 <main>:
+       8:      	push	{r7, lr}
+       a:      	mov	r7, sp
+       c:      	sub	sp, #0x4
+       e:      	movs	r0, #0x2a
+      10:      	str	r0, [sp]
+      12:      	b	0x14 <main+0xc>         @ imm = #-0x2
+      14:      	b	0x14 <main+0xc>         @ imm = #-0x4
 
-<Reset>:
-               	push	{r7, lr}
-               	mov	r7, sp
-               	bl	0x8 <main>              @ imm = #-0x16
+00000016 <Reset>:
+      16:      	push	{r7, lr}
+      18:      	mov	r7, sp
+      1a:      	bl	0x8 <main>              @ imm = #-0x16

--- a/ci/memory-layout/app.text.objdump
+++ b/ci/memory-layout/app.text.objdump
@@ -3,11 +3,11 @@ app:	file format elf32-littlearm
 
 Disassembly of section .text:
 
-<Reset>:
-               	push	{r7, lr}
-               	mov	r7, sp
-               	sub	sp, #0x4
-               	movs	r0, #0x2a
-               	str	r0, [sp]
-               	b	0x14 <Reset+0xc>        @ imm = #-0x2
-               	b	0x14 <Reset+0xc>        @ imm = #-0x4
+00000008 <Reset>:
+       8:      	push	{r7, lr}
+       a:      	mov	r7, sp
+       c:      	sub	sp, #0x4
+       e:      	movs	r0, #0x2a
+      10:      	str	r0, [sp]
+      12:      	b	0x14 <Reset+0xc>        @ imm = #-0x2
+      14:      	b	0x14 <Reset+0xc>        @ imm = #-0x4

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -52,7 +52,7 @@ main() {
 
     # check that the Reset symbol is there
     diff -b app.text.objdump \
-         <(cargo objdump --bin app -- -d --no-show-raw-insn --no-leading-addr)
+         <(cargo objdump --bin app -- -d --no-show-raw-insn --print-imm-hex)
 
     # check that the reset vector is there and has the right address
     diff -b app.vector_table.objdump \
@@ -70,7 +70,7 @@ main() {
     # check that the disassembly matches
     pushd app
     diff -b app.objdump \
-         <(cargo objdump --bin app -- -d --no-show-raw-insn --no-leading-addr)
+         <(cargo objdump --bin app -- -d --no-show-raw-insn --print-imm-hex)
     # disabled because of rust-lang/rust#53964
     # edition_check
     popd

--- a/src/main.md
+++ b/src/main.md
@@ -89,7 +89,7 @@ $ cat src/main.rs
 The disassembly will be similar but will now include the user `main` function.
 
 ``` console
-$ cargo objdump --bin app -- -d --no-show-raw-insn
+$ cargo objdump --bin app -- -d --no-show-raw-insn --print-imm-hex
 ```
 
 ``` text

--- a/src/memory-layout.md
+++ b/src/memory-layout.md
@@ -214,7 +214,7 @@ Now let's inspect the output binary to confirm the memory layout looks the way w
 (this requires [`cargo-binutils`](https://github.com/rust-embedded/cargo-binutils#readme)):
 
 ``` console
-$ cargo objdump --bin app -- -d --no-show-raw-insn
+$ cargo objdump --bin app -- -d --no-show-raw-insn --print-imm-hex
 ```
 
 ``` text


### PR DESCRIPTION
This change adds missing addresses to the disassembly in chapters `Memory Layout` and `A main interface`. The `Memory Layout` chapter does refer to the addresses in the text, while `A main interface` does not, but has been adapted for consistency in the format.

The `Exceptions` chapter referenced in #90 has already been fixed in #100, as well as the inconsistency in the translation of addresses between jump target (addr + thumb bit set) and actual target address.

Closes #90